### PR TITLE
feat(attendance): Add PDF and Telegram export for attendance plans

### DIFF
--- a/lib/core/services/export_service.dart
+++ b/lib/core/services/export_service.dart
@@ -337,6 +337,28 @@ class ExportService {
     required String? endTime,
     required List<Map<String, dynamic>> fields,
   }) async {
+    final pdf = _buildPlanPdfDocument(
+      tenantName: tenantName,
+      date: date,
+      startTime: startTime,
+      endTime: endTime,
+      fields: fields,
+    );
+
+    await Printing.layoutPdf(
+      onLayout: (format) async => pdf.save(),
+      name: '${tenantName}_Probenprogramm_$date.pdf',
+    );
+  }
+
+  /// Build a plan PDF document (shared logic for export and bytes generation)
+  pw.Document _buildPlanPdfDocument({
+    required String tenantName,
+    required String date,
+    required String startTime,
+    required String? endTime,
+    required List<Map<String, dynamic>> fields,
+  }) {
     final pdf = pw.Document();
 
     // Calculate times for each field
@@ -409,10 +431,7 @@ class ExportService {
       ),
     );
 
-    await Printing.layoutPdf(
-      onLayout: (format) async => pdf.save(),
-      name: '${tenantName}_Probenprogramm_$date.pdf',
-    );
+    return pdf;
   }
 
   /// Parse time string "HH:MM" to minutes since midnight
@@ -633,5 +652,24 @@ class ExportService {
       onLayout: (format) async => pdf.save(),
       name: '${tenantName}_Probenprogramm_2xA5_$date.pdf',
     );
+  }
+
+  /// Generate plan PDF as bytes (for sending via Telegram etc.)
+  Future<Uint8List> generatePlanPdfBytes({
+    required String tenantName,
+    required String date,
+    required String startTime,
+    required String? endTime,
+    required List<Map<String, dynamic>> fields,
+  }) async {
+    final pdf = _buildPlanPdfDocument(
+      tenantName: tenantName,
+      date: date,
+      startTime: startTime,
+      endTime: endTime,
+      fields: fields,
+    );
+
+    return pdf.save();
   }
 }

--- a/lib/features/attendance/presentation/pages/attendance_detail_page.dart
+++ b/lib/features/attendance/presentation/pages/attendance_detail_page.dart
@@ -16,6 +16,7 @@ import '../../../../core/providers/conductor_providers.dart';
 import '../../../../core/providers/song_providers.dart';
 import '../../../../core/providers/tenant_providers.dart';
 import '../../../../core/services/export_service.dart';
+import '../../../../core/services/telegram_service.dart';
 import '../../../../core/theme/app_colors.dart';
 import '../../../../core/utils/dialog_helper.dart';
 import '../../../../core/utils/toast_helper.dart';
@@ -508,9 +509,8 @@ class _AttendanceDetailPageState extends ConsumerState<AttendanceDetailPage> {
                             onEdit: () {
                               context.push('/planning/${widget.attendanceId}');
                             },
-                            onExportPdf: () async {
-                              ToastHelper.showInfo(context, 'PDF-Export wird vorbereitet...');
-                            },
+                            onExportPdf: _exportPlanPdf,
+                            onSendViaTelegram: _sendPlanViaTelegram,
                             onSharePlanChanged: _toggleSharePlan,
                           ),
 
@@ -965,6 +965,164 @@ class _AttendanceDetailPageState extends ConsumerState<AttendanceDetailPage> {
     } catch (e) {
       if (mounted) {
         ToastHelper.showError(context, 'Fehler: $e');
+      }
+    }
+  }
+
+  // ============== PLAN EXPORT METHODS ==============
+
+  Future<void> _exportPlanPdf() async {
+    final attendance = ref.read(attendanceDetailProvider(widget.attendanceId)).valueOrNull;
+    final plan = attendance?.plan;
+
+    if (plan == null || plan.isEmpty) {
+      ToastHelper.showWarning(context, 'Kein Ablaufplan zum Exportieren');
+      return;
+    }
+
+    final fields = plan['fields'] as List?;
+    if (fields == null || fields.isEmpty) {
+      ToastHelper.showWarning(context, 'Keine Programmpunkte zum Exportieren');
+      return;
+    }
+
+    // Show format selection dialog
+    final format = await showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Export-Format'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.description),
+              title: const Text('A4 (Standard)'),
+              subtitle: const Text('Ein Plan pro Seite'),
+              onTap: () => Navigator.pop(context, 'a4'),
+            ),
+            ListTile(
+              leading: const Icon(Icons.content_cut),
+              title: const Text('2x A5 auf A4'),
+              subtitle: const Text('Zwei identische Pläne (Querformat)'),
+              onTap: () => Navigator.pop(context, '2xa5'),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Abbrechen'),
+          ),
+        ],
+      ),
+    );
+
+    if (format == null || !mounted) return;
+
+    final tenant = ref.read(currentTenantProvider);
+    if (tenant == null) {
+      ToastHelper.showError(context, 'Kein Tenant ausgewählt');
+      return;
+    }
+
+    final startTime = plan['startTime'] as String? ?? attendance?.startTime ?? '17:00';
+    final endTime = plan['endTime'] as String?;
+    final dateStr = attendance?.formattedDate ?? DateTime.now().toIso8601String().substring(0, 10);
+
+    try {
+      final exportService = ExportService();
+
+      if (format == '2xa5') {
+        await exportService.exportPlanPdf2xA5(
+          context: context,
+          tenantName: tenant.shortName,
+          date: dateStr,
+          startTime: startTime,
+          endTime: endTime,
+          fields: fields.cast<Map<String, dynamic>>(),
+        );
+      } else {
+        await exportService.exportPlanPdf(
+          context: context,
+          tenantName: tenant.shortName,
+          date: dateStr,
+          startTime: startTime,
+          endTime: endTime,
+          fields: fields.cast<Map<String, dynamic>>(),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ToastHelper.showError(context, 'Fehler beim Export: $e');
+      }
+    }
+  }
+
+  Future<void> _sendPlanViaTelegram() async {
+    final attendance = ref.read(attendanceDetailProvider(widget.attendanceId)).valueOrNull;
+    final plan = attendance?.plan;
+
+    if (plan == null || plan.isEmpty) {
+      ToastHelper.showWarning(context, 'Kein Ablaufplan zum Senden');
+      return;
+    }
+
+    final fields = plan['fields'] as List?;
+    if (fields == null || fields.isEmpty) {
+      ToastHelper.showWarning(context, 'Keine Programmpunkte zum Senden');
+      return;
+    }
+
+    // Check Telegram connection
+    final notificationConfig = await ref.read(notificationConfigProvider.future);
+    if (notificationConfig == null || !notificationConfig.isConnected || notificationConfig.telegramChatId == null) {
+      if (mounted) {
+        ToastHelper.showError(
+          context,
+          'Telegram nicht verbunden. Bitte zuerst in den Einstellungen verbinden.',
+        );
+      }
+      return;
+    }
+
+    final chatId = notificationConfig.telegramChatId!;
+
+    final tenant = ref.read(currentTenantProvider);
+    if (tenant == null) {
+      if (mounted) {
+        ToastHelper.showError(context, 'Kein Tenant ausgewählt');
+      }
+      return;
+    }
+
+    final startTime = plan['startTime'] as String? ?? attendance?.startTime ?? '17:00';
+    final endTime = plan['endTime'] as String?;
+    final dateStr = attendance?.formattedDate ?? DateTime.now().toIso8601String().substring(0, 10);
+
+    try {
+      final exportService = ExportService();
+      final pdfBytes = await exportService.generatePlanPdfBytes(
+        tenantName: tenant.shortName,
+        date: dateStr,
+        startTime: startTime,
+        endTime: endTime,
+        fields: fields.cast<Map<String, dynamic>>(),
+      );
+
+      final telegramService = ref.read(telegramServiceProvider);
+      await telegramService.sendPlanPerTelegram(
+        fileBytes: pdfBytes,
+        name: '${tenant.shortName}_Plan_$dateStr',
+        chatId: chatId,
+        asImage: false,
+      );
+
+      if (mounted) {
+        ToastHelper.showSuccess(context, 'Plan per Telegram gesendet');
+      }
+    } catch (e) {
+      if (mounted) {
+        ToastHelper.showError(context, 'Fehler beim Senden: $e');
       }
     }
   }

--- a/lib/features/attendance/presentation/widgets/attendance_detail/plan_accordion.dart
+++ b/lib/features/attendance/presentation/widgets/attendance_detail/plan_accordion.dart
@@ -12,12 +12,14 @@ class PlanAccordion extends StatelessWidget {
     required this.onEdit,
     required this.onExportPdf,
     required this.onSharePlanChanged,
+    this.onSendViaTelegram,
   });
 
   final Attendance attendance;
   final VoidCallback onEdit;
   final VoidCallback onExportPdf;
   final void Function(bool) onSharePlanChanged;
+  final VoidCallback? onSendViaTelegram;
 
   @override
   Widget build(BuildContext context) {
@@ -136,8 +138,10 @@ class PlanAccordion extends StatelessWidget {
           const Divider(height: 1),
           Padding(
             padding: const EdgeInsets.all(AppDimensions.paddingS),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            child: Wrap(
+              alignment: WrapAlignment.spaceEvenly,
+              spacing: 8,
+              runSpacing: 8,
               children: [
                 TextButton.icon(
                   onPressed: onEdit,
@@ -147,8 +151,14 @@ class PlanAccordion extends StatelessWidget {
                 TextButton.icon(
                   onPressed: onExportPdf,
                   icon: const Icon(Icons.picture_as_pdf, size: 18),
-                  label: const Text('PDF exportieren'),
+                  label: const Text('PDF'),
                 ),
+                if (onSendViaTelegram != null)
+                  TextButton.icon(
+                    onPressed: onSendViaTelegram,
+                    icon: const Icon(Icons.telegram, size: 18),
+                    label: const Text('Telegram'),
+                  ),
               ],
             ),
           ),


### PR DESCRIPTION
## Summary
- Implement PDF export for attendance plans with A4/2xA5 format selection
- Add Telegram export functionality to send plans directly via Telegram bot
- Refactor ExportService to reduce code duplication with shared `_buildPlanPdfDocument()` method
- Add Telegram button to PlanAccordion widget

## Changes
- `lib/core/services/export_service.dart`: New `generatePlanPdfBytes()` method, refactored with shared PDF builder
- `lib/features/attendance/presentation/pages/attendance_detail_page.dart`: New `_exportPlanPdf()` and `_sendPlanViaTelegram()` methods
- `lib/features/attendance/presentation/widgets/attendance_detail/plan_accordion.dart`: Optional `onSendViaTelegram` callback and Telegram button

## Test plan
- [ ] Open attendance with a plan
- [ ] Click "PDF" button → Format selection dialog appears → PDF exports correctly
- [ ] Connect Telegram in settings
- [ ] Click "Telegram" button → Plan is sent to connected Telegram chat
- [ ] Without Telegram connected → Error message appears