### PR TITLE
feat(people): Refactor PersonDetailPage to inline-editing

### DIFF
--- a/lib/features/people/presentation/pages/person_detail_page.dart
+++ b/lib/features/people/presentation/pages/person_detail_page.dart
@@ -2,23 +2,17 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 import '../../../../core/config/supabase_config.dart';
 import '../../../../core/constants/app_constants.dart';
 import '../../../../core/constants/enums.dart';
 import '../../../../core/providers/group_providers.dart';
-import '../../../../core/providers/parent_providers.dart';
 import '../../../../core/providers/player_providers.dart';
 import '../../../../core/providers/realtime_providers.dart';
-import '../../../../core/providers/shift_providers.dart';
-import '../../../../core/providers/teacher_providers.dart';
-import '../../../../core/theme/app_colors.dart';
-import '../../../../data/models/parent/parent_model.dart';
-import '../../../../data/models/person/person.dart';
-import '../../../../data/models/shift/shift_plan.dart';
-import '../../../../data/models/tenant/tenant.dart';
 import '../../../../core/providers/tenant_providers.dart';
+import '../../../../core/theme/app_colors.dart';
+import '../../../../data/models/person/person.dart';
+import '../widgets/person_detail/person_detail.dart';
 
 /// Provider for single person with group name
 final personProvider =
@@ -45,14 +39,11 @@ final personProvider =
 });
 
 /// Provider for person attendance statistics
-/// FN-010: Added tenantId filter for Multi-Tenant Security
 final personAttendanceStatsProvider =
     FutureProvider.family<Map<String, dynamic>, int>((ref, personId) async {
   final supabase = ref.watch(supabaseClientProvider);
   final tenant = ref.watch(currentTenantProvider);
 
-  // Guard against null tenant - Multi-Tenant Security
-  // RT-001: Safe null check - store tenantId in local variable after check
   final tenantId = tenant?.id;
   if (tenantId == null) {
     return {
@@ -63,8 +54,6 @@ final personAttendanceStatsProvider =
     };
   }
 
-  // BL-001: person_attendances has no tenantId column
-  // Filter via inner join on attendance table which has tenantId
   final response = await supabase
       .from('person_attendances')
       .select('status, attendance:attendance_id!inner(id, date, tenantId)')
@@ -74,7 +63,6 @@ final personAttendanceStatsProvider =
   final attendances = response as List;
   final now = DateTime.now();
 
-  // Filter to only past attendances
   final pastAttendances = attendances.where((a) {
     final attendance = a['attendance'] as Map<String, dynamic>?;
     final date = DateTime.tryParse(attendance?['date'] ?? '');
@@ -82,8 +70,6 @@ final personAttendanceStatsProvider =
   }).toList();
 
   final total = pastAttendances.length;
-  // BL-001: Fix attended calculation - use status field instead of non-existent 'attended'
-  // Status values: 1=present, 3=late, 5=lateExcused (all count as attended)
   final attended = pastAttendances.where((a) {
     final status = a['status'];
     if (status is int) {
@@ -92,12 +78,11 @@ final personAttendanceStatsProvider =
     return false;
   }).length;
   final percentage = total > 0 ? (attended / total * 100).round() : 0;
-  
-  // Count late arrivals (status 3 = late, 5 = lateExcused)
+
   final lateCount = pastAttendances.where((a) {
     final status = a['status'];
     if (status is int) {
-      return status == 3 || status == 5; // AttendanceStatus.late or lateExcused
+      return status == 3 || status == 5;
     }
     return false;
   }).length;
@@ -119,18 +104,14 @@ final personHistoryProvider =
 
   if (person == null || tenant == null) return [];
 
-  // Get today's date in ISO format for comparison
   final today = DateTime.now().toIso8601String().substring(0, 10);
 
-  // Get attendance history - use attendance_id join like Ionic does
-  // BL-003/SEC: person_attendances has no tenantId - use inner join (!inner) to filter
   final attendanceResponse = await supabase
       .from('person_attendances')
       .select('*, attendance:attendance_id!inner(id, date, type, typeInfo, type_id, tenantId)')
       .eq('person_id', personId)
       .eq('attendance.tenantId', tenant.id!);
 
-  // Get attendance types for title lookup
   List<Map<String, dynamic>> attendanceTypes = [];
   final typesResponse = await supabase
       .from('attendance_types')
@@ -139,9 +120,8 @@ final personHistoryProvider =
   attendanceTypes = List<Map<String, dynamic>>.from(typesResponse as List);
 
   final attendanceHistory = (attendanceResponse as List)
-      .where((a) => a['attendance'] != null) // Filter out null attendance
+      .where((a) => a['attendance'] != null)
       .where((a) {
-        // Only past dates
         final attendance = a['attendance'] as Map<String, dynamic>?;
         final dateStr = attendance?['date']?.toString();
         if (dateStr == null) return false;
@@ -150,10 +130,8 @@ final personHistoryProvider =
       .map((a) {
     final attendance = a['attendance'] as Map<String, dynamic>?;
     final typeId = attendance?['type_id'];
-    // typeInfo is a String in the database, not a Map
     final typeInfo = attendance?['typeInfo']?.toString();
 
-    // Get title from attendance type (like Ionic's Utils.getTypeTitle)
     String meetingName = '';
     final attType = attendanceTypes.firstWhere(
       (t) => t['id'] == typeId,
@@ -161,15 +139,11 @@ final personHistoryProvider =
     );
     if (attType.isNotEmpty) {
       final typeName = attType['name']?.toString() ?? '';
-      // typeInfo is the title if provided, otherwise use type name
       meetingName = (typeInfo != null && typeInfo.isNotEmpty) ? typeInfo : typeName;
     } else {
-      // Fallback to typeInfo or old type field
       meetingName = typeInfo ?? attendance?['type']?.toString() ?? 'Anwesenheit';
     }
 
-    // Determine status text based on integer status value
-    // Status values: 0=neutral, 1=present, 2=excused, 3=late, 4=absent, 5=lateExcused
     final statusValue = a['status'];
     int statusInt = 0;
     if (statusValue is int) {
@@ -180,22 +154,22 @@ final personHistoryProvider =
 
     String displayStatus;
     switch (statusInt) {
-      case 1: // present
+      case 1:
         displayStatus = 'X';
         break;
-      case 2: // excused
+      case 2:
         displayStatus = 'E';
         break;
-      case 3: // late
+      case 3:
         displayStatus = 'L';
         break;
-      case 4: // absent
+      case 4:
         displayStatus = 'A';
         break;
-      case 5: // lateExcused
+      case 5:
         displayStatus = 'L';
         break;
-      case 0: // neutral
+      case 0:
       default:
         displayStatus = 'N';
     }
@@ -210,7 +184,6 @@ final personHistoryProvider =
     };
   }).toList();
 
-  // Get player history from person model
   final playerHistory = person.history.map((h) {
     return {
       'date': h.date,
@@ -221,7 +194,6 @@ final personHistoryProvider =
     };
   }).toList();
 
-  // Combine and sort by date descending
   final allHistory = [...attendanceHistory, ...playerHistory];
   allHistory.sort((a, b) {
     final dateA = DateTime.tryParse(a['date']?.toString() ?? '') ?? DateTime(1900);
@@ -232,7 +204,7 @@ final personHistoryProvider =
   return allHistory.take(100).toList();
 });
 
-/// Person detail page
+/// Person detail page - with inline editing
 class PersonDetailPage extends ConsumerWidget {
   const PersonDetailPage({super.key, required this.personId});
 
@@ -290,33 +262,21 @@ class _PersonDetailContent extends ConsumerStatefulWidget {
 }
 
 class _PersonDetailContentState extends ConsumerState<_PersonDetailContent> {
-  bool _isEditing = false;
+  // Draft state for inline editing
+  late Person _draft;
   bool _hasChanges = false;
   bool _isSaving = false;
+  final Set<String> _changedFields = {};
 
-  // FN-006: Form key for validation
-  final _formKey = GlobalKey<FormState>();
-
-  // Form controllers
-  late TextEditingController _firstNameController;
-  late TextEditingController _lastNameController;
-  late TextEditingController _phoneController;
-  late TextEditingController _emailController;
-  late TextEditingController _notesController;
-  late TextEditingController _otherExerciseController;
-  
-  // Form values
+  // Separate draft values for fields that need special handling
   late int? _selectedGroupId;
-  late DateTime? _birthday;
-  late DateTime? _playsSince;
-  late DateTime? _joined;
-  late bool _isLeader;
-  late bool _hasTeacher;
   late int? _selectedTeacherId;
   late String? _selectedShiftId;
   late String? _selectedShiftName;
   late DateTime? _shiftStart;
   late int? _selectedParentId;
+  late bool _isLeader;
+  late bool _hasTeacher;
   late Map<String, dynamic> _additionalFieldValues;
 
   // Section states
@@ -329,33 +289,33 @@ class _PersonDetailContentState extends ConsumerState<_PersonDetailContent> {
   bool _problemSolved = false;
   String _problemNotes = '';
 
-  // FN-005: User role state for refresh after update
+  // User role state
   Role? _userRole;
   bool _isLoadingRole = false;
 
   @override
   void initState() {
     super.initState();
-    _initFormData();
+    _initDraft();
     _loadUserRole();
   }
 
-  // FN-005: Load user role on init - actual loading deferred to didChangeDependencies
+  void _initDraft() {
+    final p = widget.person;
+    _draft = p;
+    _selectedGroupId = p.instrument;
+    _selectedTeacherId = p.teacher;
+    _selectedShiftId = p.shiftId;
+    _selectedShiftName = p.shiftName;
+    _shiftStart = p.shiftStart != null ? DateTime.tryParse(p.shiftStart!) : null;
+    _selectedParentId = p.parentId;
+    _isLeader = p.isLeader;
+    _hasTeacher = p.hasTeacher;
+    _additionalFieldValues = Map.from(p.additionalFields ?? {});
+  }
+
   Future<void> _loadUserRole() async {
     if (widget.person.appId == null) return;
-    // Defer to didChangeDependencies for tenant access via ref
-  }
-
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    // FN-005: Load role when dependencies are ready
-    if (_userRole == null && !_isLoadingRole && widget.person.appId != null) {
-      _fetchUserRole();
-    }
-  }
-
-  Future<void> _fetchUserRole() async {
     final tenant = ref.read(currentTenantProvider);
     final appId = widget.person.appId;
     final tenantId = tenant?.id;
@@ -378,62 +338,92 @@ class _PersonDetailContentState extends ConsumerState<_PersonDetailContent> {
     }
   }
 
-  void _initFormData() {
-    final p = widget.person;
-    _firstNameController = TextEditingController(text: p.firstName);
-    _lastNameController = TextEditingController(text: p.lastName);
-    _phoneController = TextEditingController(text: p.phone ?? '');
-    _emailController = TextEditingController(text: p.email ?? '');
-    _notesController = TextEditingController(text: p.notes ?? '');
-    _otherExerciseController = TextEditingController(text: p.otherExercise ?? '');
-    
-    _selectedGroupId = p.instrument;
-    _birthday = p.birthday != null ? DateTime.tryParse(p.birthday!) : null;
-    _playsSince = p.playsSince != null ? DateTime.tryParse(p.playsSince!) : null;
-    _joined = p.joined != null ? DateTime.tryParse(p.joined!) : null;
-    _isLeader = p.isLeader;
-    _hasTeacher = p.hasTeacher;
-    _selectedTeacherId = p.teacher;
-    _selectedShiftId = p.shiftId;
-    _selectedShiftName = p.shiftName;
-    _shiftStart = p.shiftStart != null ? DateTime.tryParse(p.shiftStart!) : null;
-    _selectedParentId = p.parentId;
-    _additionalFieldValues = Map.from(p.additionalFields ?? {});
-  }
-  
-  @override
-  void dispose() {
-    _firstNameController.dispose();
-    _lastNameController.dispose();
-    _phoneController.dispose();
-    _emailController.dispose();
-    _notesController.dispose();
-    _otherExerciseController.dispose();
-    super.dispose();
-  }
-  
-  void _markChanged() {
-    if (!_hasChanges) {
-      setState(() => _hasChanges = true);
+  Future<Role?> _getUserRole(String userId, int tenantId) async {
+    final supabase = ref.read(supabaseClientProvider);
+    try {
+      final response = await supabase
+          .from('tenantUsers')
+          .select('role')
+          .eq('userId', userId)
+          .eq('tenantId', tenantId)
+          .maybeSingle();
+
+      if (response == null) return null;
+      return Role.fromValue(response['role'] as int? ?? 99);
+    } catch (e) {
+      return null;
     }
   }
 
-  Future<void> _launchUrl(String url) async {
-    final uri = Uri.parse(url);
-    if (await canLaunchUrl(uri)) {
-      await launchUrl(uri);
-    }
+  void _onFieldChanged(String field, dynamic value) {
+    setState(() {
+      _changedFields.add(field);
+      _hasChanges = true;
+
+      // Handle special fields
+      if (field == 'firstName') {
+        _draft = _draft.copyWith(firstName: value as String? ?? '');
+      } else if (field == 'lastName') {
+        _draft = _draft.copyWith(lastName: value as String? ?? '');
+      } else if (field == 'notes') {
+        _draft = _draft.copyWith(notes: value as String?);
+      } else if (field == 'phone') {
+        _draft = _draft.copyWith(phone: value as String?);
+      } else if (field == 'birthday') {
+        _draft = _draft.copyWith(birthday: value as String?);
+      } else if (field == 'playsSince') {
+        _draft = _draft.copyWith(playsSince: value as String?);
+      } else if (field == 'joined') {
+        _draft = _draft.copyWith(joined: value as String?);
+      } else if (field == 'instrument') {
+        _selectedGroupId = value as int?;
+        _draft = _draft.copyWith(instrument: value);
+      } else if (field == 'isLeader') {
+        _isLeader = value as bool;
+        _draft = _draft.copyWith(isLeader: value);
+      } else if (field == 'hasTeacher') {
+        _hasTeacher = value as bool;
+        _draft = _draft.copyWith(hasTeacher: value);
+      } else if (field == 'teacher') {
+        _selectedTeacherId = value as int?;
+        _draft = _draft.copyWith(teacher: value);
+      } else if (field == 'shiftId') {
+        _selectedShiftId = value as String?;
+        _draft = _draft.copyWith(shiftId: value);
+      } else if (field == 'shiftName') {
+        _selectedShiftName = value as String?;
+        _draft = _draft.copyWith(shiftName: value);
+      } else if (field == 'shiftStart') {
+        _shiftStart = value != null ? DateTime.tryParse(value as String) : null;
+        _draft = _draft.copyWith(shiftStart: value as String?);
+      } else if (field == 'parentId') {
+        _selectedParentId = value as int?;
+        _draft = _draft.copyWith(parentId: value);
+      } else if (field == 'otherExercise') {
+        _draft = _draft.copyWith(otherExercise: value as String?);
+      } else if (field.startsWith('additionalFields.')) {
+        final fieldId = field.substring('additionalFields.'.length);
+        _additionalFieldValues[fieldId] = value;
+      }
+    });
   }
-  
+
   Future<void> _saveChanges() async {
-    if (_isSaving) return;
+    if (_isSaving || !_hasChanges) return;
 
-    // FN-006: Validate form before saving
-    if (!_formKey.currentState!.validate()) {
+    // Validate required fields
+    if (_draft.firstName.isEmpty || _draft.lastName.isEmpty) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Vorname und Nachname sind erforderlich'),
+            backgroundColor: AppColors.danger,
+          ),
+        );
+      }
       return;
     }
 
-    // SEC-001: Check role before saving
     final currentRole = ref.read(currentRoleProvider);
     if (!currentRole.canEdit) {
       if (mounted) {
@@ -448,12 +438,12 @@ class _PersonDetailContentState extends ConsumerState<_PersonDetailContent> {
     }
 
     setState(() => _isSaving = true);
-    
+
     try {
       final supabase = ref.read(supabaseClientProvider);
       final person = widget.person;
-      
-      // Build history entry if group changed
+
+      // Build history entries for tracked changes
       final List<Map<String, dynamic>> newHistoryEntries = [];
       if (_selectedGroupId != person.instrument) {
         final groups = await ref.read(groupsMapProvider.future);
@@ -465,21 +455,19 @@ class _PersonDetailContentState extends ConsumerState<_PersonDetailContent> {
           'type': PlayerHistoryType.instrumentChange.value,
         });
       }
-      
-      // Build history entry if notes changed
-      if (_notesController.text != (person.notes ?? '')) {
+
+      if (_draft.notes != (person.notes ?? '')) {
         newHistoryEntries.add({
           'date': DateTime.now().toIso8601String(),
           'text': person.notes ?? 'Keine Notiz',
           'type': PlayerHistoryType.notes.value,
         });
       }
-      
+
       final existingHistory = person.history.map((h) => h.toJson()).toList();
       final updatedHistory = [...existingHistory, ...newHistoryEntries];
       final tenant = ref.read(currentTenantProvider);
 
-      // RT-001: Safe null checks for person.id and tenant.id
       final personId = person.id;
       final tenantId = tenant?.id;
       if (personId == null || tenantId == null) {
@@ -487,15 +475,15 @@ class _PersonDetailContentState extends ConsumerState<_PersonDetailContent> {
       }
 
       await supabase.from('player').update({
-        'firstName': _firstNameController.text,
-        'lastName': _lastNameController.text,
-        'phone': _phoneController.text.isEmpty ? null : _phoneController.text,
-        'notes': _notesController.text.isEmpty ? null : _notesController.text,
-        'otherExercise': _otherExerciseController.text.isEmpty ? null : _otherExerciseController.text,
+        'firstName': _draft.firstName,
+        'lastName': _draft.lastName,
+        'phone': _draft.phone?.isEmpty ?? true ? null : _draft.phone,
+        'notes': _draft.notes?.isEmpty ?? true ? null : _draft.notes,
+        'otherExercise': _draft.otherExercise?.isEmpty ?? true ? null : _draft.otherExercise,
         'instrument': _selectedGroupId,
-        'birthday': _birthday?.toIso8601String(),
-        'playsSince': _playsSince?.toIso8601String(),
-        'joined': _joined?.toIso8601String(),
+        'birthday': _draft.birthday,
+        'playsSince': _draft.playsSince,
+        'joined': _draft.joined,
         'isLeader': _isLeader,
         'hasTeacher': _hasTeacher,
         'teacher': _hasTeacher ? _selectedTeacherId : null,
@@ -507,15 +495,15 @@ class _PersonDetailContentState extends ConsumerState<_PersonDetailContent> {
         'history': updatedHistory,
         'additional_fields': _additionalFieldValues.isNotEmpty ? _additionalFieldValues : null,
       }).eq('id', personId).eq('tenantId', tenantId);
-      
+
       ref.invalidate(personProvider(widget.personId));
       ref.invalidate(realtimePlayersProvider);
-      
+
       setState(() {
         _hasChanges = false;
-        _isEditing = false;
+        _changedFields.clear();
       });
-      
+
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(
@@ -656,7 +644,6 @@ class _PersonDetailContentState extends ConsumerState<_PersonDetailContent> {
   }
 
   Future<void> _pausePerson(String reason, String? until) async {
-    // SEC-001: Check role before pausing
     final currentRole = ref.read(currentRoleProvider);
     if (!currentRole.canEdit) {
       if (mounted) {
@@ -673,7 +660,6 @@ class _PersonDetailContentState extends ConsumerState<_PersonDetailContent> {
     final repository = ref.read(playerRepositoryWithTenantProvider);
     final person = widget.person;
 
-    // Format reason with date if provided - RT-005: Safe date parsing
     String reasonText = reason;
     if (until != null) {
       final parsedDate = DateTime.tryParse(until);
@@ -707,7 +693,6 @@ class _PersonDetailContentState extends ConsumerState<_PersonDetailContent> {
   }
 
   Future<void> _unpausePerson() async {
-    // SEC-001: Check role before unpausing
     final currentRole = ref.read(currentRoleProvider);
     if (!currentRole.canEdit) {
       if (mounted) {
@@ -808,7 +793,6 @@ class _PersonDetailContentState extends ConsumerState<_PersonDetailContent> {
   }
 
   Future<void> _archivePerson(String date, String note) async {
-    // SEC-001: Check role before archiving
     final currentRole = ref.read(currentRoleProvider);
     if (!currentRole.canEdit) {
       if (mounted) {
@@ -940,1083 +924,8 @@ class _PersonDetailContentState extends ConsumerState<_PersonDetailContent> {
       ),
     );
   }
-  
-  Future<void> _selectDate(String field) async {
-    DateTime initialDate;
-    switch (field) {
-      case 'birthday':
-        initialDate = _birthday ?? DateTime(2000, 1, 1);
-        break;
-      case 'playsSince':
-        initialDate = _playsSince ?? DateTime.now();
-        break;
-      case 'joined':
-        initialDate = _joined ?? DateTime.now();
-        break;
-      default:
-        return;
-    }
-    
-    final date = await showDatePicker(
-      context: context,
-      initialDate: initialDate,
-      firstDate: DateTime(1900),
-      lastDate: DateTime.now(),
-    );
-    
-    if (date != null) {
-      setState(() {
-        switch (field) {
-          case 'birthday':
-            _birthday = date;
-            break;
-          case 'playsSince':
-            _playsSince = date;
-            break;
-          case 'joined':
-            _joined = date;
-            break;
-        }
-      });
-      _markChanged();
-    }
-  }
 
-  @override
-  Widget build(BuildContext context) {
-    final person = widget.person;
-    final statsAsync = ref.watch(personAttendanceStatsProvider(widget.personId));
-    final groupsAsync = ref.watch(groupsMapProvider);
-
-    return PopScope(
-      canPop: !_hasChanges,
-      onPopInvokedWithResult: (didPop, result) async {
-        if (didPop) return;
-        // User tried to pop but canPop was false (has unsaved changes)
-        final shouldDiscard = await showDialog<bool>(
-          context: context,
-          builder: (context) => AlertDialog(
-            title: const Text('Änderungen verwerfen?'),
-            content: const Text('Du hast ungespeicherte Änderungen. Möchtest du diese verwerfen?'),
-            actions: [
-              TextButton(onPressed: () => Navigator.pop(context, false), child: const Text('Abbrechen')),
-              FilledButton(onPressed: () => Navigator.pop(context, true), child: const Text('Verwerfen')),
-            ],
-          ),
-        );
-        if (shouldDiscard == true && context.mounted) {
-          Navigator.of(context).pop();
-        }
-      },
-      child: Scaffold(
-        appBar: AppBar(
-          title: Text(_isEditing ? 'Person bearbeiten' : person.fullName),
-          backgroundColor: person.isCritical ? AppColors.danger : null,
-          actions: [
-            // SEC-001: Only show edit button if user has permission
-            if (!_isEditing && ref.watch(currentRoleProvider).canEdit)
-              IconButton(
-                icon: const Icon(Icons.edit),
-                tooltip: 'Bearbeiten',
-                onPressed: () => setState(() => _isEditing = true),
-              ),
-            // SEC-001: Only show more actions if user has permission
-            if (ref.watch(currentRoleProvider).canEdit)
-              IconButton(
-                icon: const Icon(Icons.more_vert),
-                tooltip: 'Mehr',
-                onPressed: _showMoreActions,
-              ),
-          ],
-        ),
-        body: ListView(
-          padding: const EdgeInsets.only(bottom: 100),
-          children: [
-            // Header with avatar and stats
-            _buildHeader(person, statsAsync),
-            
-            // Status badges
-            if (_hasStatusBadges(person))
-              Padding(
-                padding: const EdgeInsets.all(AppDimensions.paddingM),
-                child: Wrap(
-                  spacing: AppDimensions.paddingS,
-                  runSpacing: AppDimensions.paddingS,
-                  children: _buildStatusBadges(person),
-                ),
-              ),
-
-            // Edit Form or View Mode
-            if (_isEditing)
-              _buildEditForm(groupsAsync)
-            else ...[
-              // Late Warning Card
-              _buildLateWarningCard(person, statsAsync),
-              _buildNameSection(person),
-              // Problem Person Accordion (only for critical persons)
-              if (person.isCritical)
-                _buildAccordionSection(
-                  title: 'Problemfall',
-                  isExpanded: _showProblemfall,
-                  onToggle: () => setState(() => _showProblemfall = !_showProblemfall),
-                  child: _buildProblemfallContent(person),
-                ),
-              _buildAccordionSection(
-                title: 'Allgemein',
-                isExpanded: _showAllgemein,
-                onToggle: () => setState(() => _showAllgemein = !_showAllgemein),
-                child: _buildAllgemeinContent(person),
-              ),
-              if (person.email != null || person.appId != null)
-                _buildAccordionSection(
-                  title: 'Account',
-                  isExpanded: _showAccount,
-                  onToggle: () => setState(() => _showAccount = !_showAccount),
-                  child: _buildAccountContent(person),
-                ),
-              _buildAccordionSection(
-                title: 'Historie',
-                isExpanded: _showHistorie,
-                onToggle: () => setState(() => _showHistorie = !_showHistorie),
-                child: _buildHistoryContent(),
-              ),
-            ],
-          ],
-        ),
-        floatingActionButton: _isEditing
-            ? FloatingActionButton.extended(
-                onPressed: _isSaving ? null : _saveChanges,
-                icon: _isSaving 
-                    ? const SizedBox(width: 20, height: 20, child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white))
-                    : const Icon(Icons.save),
-                label: Text(_isSaving ? 'Speichern...' : 'Speichern'),
-                backgroundColor: _hasChanges ? AppColors.primary : AppColors.medium,
-              )
-            : null,
-      ),
-    );
-  }
-  
-  Widget _buildEditForm(AsyncValue<Map<int, String>> groupsAsync) {
-    final tenant = ref.watch(currentTenantProvider);
-    final extraFields = tenant?.additionalFields ?? [];
-
-    // FN-006: Wrap in Form for validation
-    return Form(
-      key: _formKey,
-      child: Card(
-        margin: const EdgeInsets.all(AppDimensions.paddingM),
-        child: Padding(
-          padding: const EdgeInsets.all(AppDimensions.paddingM),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              // Name Row
-              Row(
-                children: [
-                  Expanded(
-                    // FN-006: Use TextFormField with validator
-                    child: TextFormField(
-                      controller: _firstNameController,
-                      decoration: const InputDecoration(labelText: 'Vorname *'),
-                      onChanged: (_) => _markChanged(),
-                      validator: (value) {
-                        if (value == null || value.trim().isEmpty) {
-                          return 'Vorname ist erforderlich';
-                        }
-                        return null;
-                      },
-                    ),
-                  ),
-                  const SizedBox(width: AppDimensions.paddingM),
-                  Expanded(
-                    // FN-006: Use TextFormField with validator
-                    child: TextFormField(
-                      controller: _lastNameController,
-                      decoration: const InputDecoration(labelText: 'Nachname *'),
-                      onChanged: (_) => _markChanged(),
-                      validator: (value) {
-                        if (value == null || value.trim().isEmpty) {
-                          return 'Nachname ist erforderlich';
-                        }
-                        return null;
-                      },
-                    ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: AppDimensions.paddingM),
-
-              // Notes
-              TextFormField(
-                controller: _notesController,
-                decoration: const InputDecoration(labelText: 'Notizen'),
-                maxLines: 3,
-                onChanged: (_) => _markChanged(),
-              ),
-            const SizedBox(height: AppDimensions.paddingL),
-
-            // Group Dropdown
-            Text('Gruppe', style: Theme.of(context).textTheme.labelMedium),
-            const SizedBox(height: AppDimensions.paddingXS),
-            groupsAsync.when(
-              loading: () => const LinearProgressIndicator(),
-              error: (e, _) => Text('Fehler: $e'),
-              data: (groups) => DropdownButtonFormField<int>(
-                value: _selectedGroupId,
-                decoration: const InputDecoration(border: OutlineInputBorder()),
-                items: groups.entries.map((e) => DropdownMenuItem(value: e.key, child: Text(e.value))).toList(),
-                onChanged: (value) {
-                  setState(() => _selectedGroupId = value);
-                  _markChanged();
-                },
-              ),
-            ),
-            const SizedBox(height: AppDimensions.paddingM),
-
-            // Phone
-            TextField(
-              controller: _phoneController,
-              decoration: const InputDecoration(labelText: 'Telefon-/Handynummer'),
-              keyboardType: TextInputType.phone,
-              onChanged: (_) => _markChanged(),
-            ),
-            const SizedBox(height: AppDimensions.paddingM),
-
-            // Birthday
-            ListTile(
-              contentPadding: EdgeInsets.zero,
-              title: const Text('Geburtsdatum'),
-              subtitle: Text(_birthday != null ? DateFormat('dd.MM.yyyy').format(_birthday!) : 'Nicht angegeben'),
-              trailing: const Icon(Icons.calendar_today),
-              onTap: () => _selectDate('birthday'),
-            ),
-
-            // Plays Since
-            ListTile(
-              contentPadding: EdgeInsets.zero,
-              title: const Text('Spielt auf dem Instrument seit'),
-              subtitle: Text(_playsSince != null ? DateFormat('dd.MM.yyyy').format(_playsSince!) : 'Nicht angegeben'),
-              trailing: const Icon(Icons.calendar_today),
-              onTap: () => _selectDate('playsSince'),
-            ),
-
-            // Joined
-            ListTile(
-              contentPadding: EdgeInsets.zero,
-              title: const Text('Beigetreten am'),
-              subtitle: Text(_joined != null ? DateFormat('dd.MM.yyyy').format(_joined!) : 'Nicht angegeben'),
-              trailing: const Icon(Icons.calendar_today),
-              onTap: () => _selectDate('joined'),
-            ),
-
-            // Is Leader
-            SwitchListTile(
-              contentPadding: EdgeInsets.zero,
-              title: const Text('Stimmführer'),
-              value: _isLeader,
-              onChanged: (value) {
-                setState(() => _isLeader = value);
-                _markChanged();
-              },
-            ),
-
-            // Has Teacher
-            SwitchListTile(
-              contentPadding: EdgeInsets.zero,
-              title: const Text('Spielt beim Lehrer'),
-              value: _hasTeacher,
-              onChanged: (value) {
-                setState(() {
-                  _hasTeacher = value;
-                  if (!value) _selectedTeacherId = null;
-                });
-                _markChanged();
-              },
-            ),
-
-            // Teacher Dropdown (only shown when hasTeacher is true)
-            if (_hasTeacher) ...[
-              const SizedBox(height: AppDimensions.paddingM),
-              Text('Lehrer', style: Theme.of(context).textTheme.labelMedium),
-              const SizedBox(height: AppDimensions.paddingXS),
-              ref.watch(teachersProvider).when(
-                loading: () => const LinearProgressIndicator(),
-                error: (e, _) => Text('Fehler: $e'),
-                data: (teachers) => DropdownButtonFormField<int>(
-                  value: _selectedTeacherId,
-                  decoration: const InputDecoration(
-                    border: OutlineInputBorder(),
-                    hintText: 'Lehrer auswählen',
-                  ),
-                  items: [
-                    const DropdownMenuItem<int>(value: null, child: Text('Kein Lehrer')),
-                    ...teachers.map((t) => DropdownMenuItem(
-                      value: t.id,
-                      child: Text(t.fullName),
-                    )),
-                  ],
-                  onChanged: (value) {
-                    setState(() => _selectedTeacherId = value);
-                    _markChanged();
-                  },
-                ),
-              ),
-            ],
-
-            // Shift Plan Dropdown
-            const SizedBox(height: AppDimensions.paddingM),
-            Text('Schichtplan', style: Theme.of(context).textTheme.labelMedium),
-            const SizedBox(height: AppDimensions.paddingXS),
-            ref.watch(shiftsProvider).when(
-              loading: () => const LinearProgressIndicator(),
-              error: (e, _) => Text('Fehler: $e'),
-              data: (shifts) {
-                final selectedShift = shifts.where((s) => s.id == _selectedShiftId).firstOrNull;
-                return Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    DropdownButtonFormField<String>(
-                      value: _selectedShiftId,
-                      decoration: const InputDecoration(
-                        border: OutlineInputBorder(),
-                        hintText: 'Schichtplan auswählen',
-                      ),
-                      items: [
-                        const DropdownMenuItem<String>(value: null, child: Text('Kein Schichtplan')),
-                        ...shifts.map((s) => DropdownMenuItem(
-                          value: s.id,
-                          child: Text(s.name),
-                        )),
-                      ],
-                      onChanged: (value) {
-                        setState(() {
-                          _selectedShiftId = value;
-                          // Reset shift name and start when shift changes
-                          _selectedShiftName = null;
-                          _shiftStart = null;
-                        });
-                        _markChanged();
-                      },
-                    ),
-                    // Show shift name dropdown or date picker based on shift type
-                    if (selectedShift != null) ...[
-                      const SizedBox(height: AppDimensions.paddingM),
-                      if (selectedShift.hasNamedShifts) ...[
-                        Text('Schicht', style: Theme.of(context).textTheme.labelMedium),
-                        const SizedBox(height: AppDimensions.paddingXS),
-                        Builder(builder: (context) {
-                          final uniqueShiftNames = selectedShift.shifts
-                              .map((s) => s.name)
-                              .toSet()
-                              .toList();
-                          return DropdownButtonFormField<String>(
-                            value: _selectedShiftName,
-                            decoration: const InputDecoration(
-                              border: OutlineInputBorder(),
-                              hintText: 'Schicht auswählen',
-                            ),
-                            items: [
-                              const DropdownMenuItem<String>(value: null, child: Text('Keine Schicht')),
-                              ...uniqueShiftNames.map((name) => DropdownMenuItem(
-                                value: name,
-                                child: Text(name),
-                              )),
-                            ],
-                            onChanged: (value) {
-                              setState(() => _selectedShiftName = value);
-                              _markChanged();
-                            },
-                          );
-                        }),
-                      ] else ...[
-                        ListTile(
-                          contentPadding: EdgeInsets.zero,
-                          title: const Text('Schichtplan-Start'),
-                          subtitle: Text(_shiftStart != null
-                            ? DateFormat('dd.MM.yyyy').format(_shiftStart!)
-                            : 'Nicht angegeben'),
-                          trailing: const Icon(Icons.calendar_today),
-                          onTap: () async {
-                            final date = await showDatePicker(
-                              context: context,
-                              initialDate: _shiftStart ?? DateTime.now(),
-                              firstDate: DateTime(2000),
-                              lastDate: DateTime(2100),
-                            );
-                            if (date != null) {
-                              setState(() => _shiftStart = date);
-                              _markChanged();
-                            }
-                          },
-                        ),
-                      ],
-                    ],
-                  ],
-                );
-              },
-            ),
-
-            // Parent Dropdown
-            const SizedBox(height: AppDimensions.paddingM),
-            Text('Erziehungsberechtigter', style: Theme.of(context).textTheme.labelMedium),
-            const SizedBox(height: AppDimensions.paddingXS),
-            ref.watch(parentsProvider).when(
-              loading: () => const LinearProgressIndicator(),
-              error: (e, _) => Text('Fehler: $e'),
-              data: (parents) => DropdownButtonFormField<int>(
-                value: _selectedParentId,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
-                  hintText: 'Erziehungsberechtigten auswählen',
-                ),
-                items: [
-                  const DropdownMenuItem<int>(value: null, child: Text('Kein Erziehungsberechtigter')),
-                  ...parents.map((p) => DropdownMenuItem(
-                    value: p.id,
-                    child: Text(p.fullName),
-                  )),
-                ],
-                onChanged: (value) {
-                  setState(() => _selectedParentId = value);
-                  _markChanged();
-                },
-              ),
-            ),
-            const SizedBox(height: AppDimensions.paddingM),
-
-            // Other Exercise
-            TextField(
-              controller: _otherExerciseController,
-              decoration: const InputDecoration(labelText: 'Sonstige Dienste'),
-              onChanged: (_) => _markChanged(),
-            ),
-
-            // Extra Fields Section
-            if (extraFields.isNotEmpty) ...[
-              const SizedBox(height: AppDimensions.paddingL),
-              const Divider(),
-              const SizedBox(height: AppDimensions.paddingS),
-              Text(
-                'Zusatzfelder',
-                style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                  fontWeight: FontWeight.w600,
-                  color: AppColors.primary,
-                ),
-              ),
-              const SizedBox(height: AppDimensions.paddingM),
-              ...extraFields.map((field) => _buildExtraFieldInput(field)),
-            ],
-
-            const SizedBox(height: AppDimensions.paddingL),
-
-            // Cancel button
-            OutlinedButton(
-              onPressed: () {
-                _initFormData();
-                setState(() {
-                  _isEditing = false;
-                  _hasChanges = false;
-                });
-              },
-              child: const Text('Abbrechen'),
-            ),
-          ],
-        ),
-      ),
-    ),  // FN-006: Close Form widget
-    );
-  }
-
-  Widget _buildExtraFieldInput(ExtraField field) {
-    final currentValue = _additionalFieldValues[field.id] ?? field.defaultValue;
-
-    switch (field.type) {
-      case 'text':
-        return Padding(
-          padding: const EdgeInsets.only(bottom: AppDimensions.paddingM),
-          // FN-001: Use TextFormField with initialValue to avoid memory leak
-          child: TextFormField(
-            decoration: InputDecoration(labelText: field.name),
-            initialValue: currentValue?.toString() ?? '',
-            onChanged: (value) {
-              _additionalFieldValues[field.id] = value;
-              _markChanged();
-            },
-          ),
-        );
-
-      case 'textarea':
-        return Padding(
-          padding: const EdgeInsets.only(bottom: AppDimensions.paddingM),
-          // FN-001: Use TextFormField with initialValue to avoid memory leak
-          child: TextFormField(
-            decoration: InputDecoration(labelText: field.name),
-            maxLines: 3,
-            initialValue: currentValue?.toString() ?? '',
-            onChanged: (value) {
-              _additionalFieldValues[field.id] = value;
-              _markChanged();
-            },
-          ),
-        );
-
-      case 'number':
-        return Padding(
-          padding: const EdgeInsets.only(bottom: AppDimensions.paddingM),
-          // FN-001: Use TextFormField with initialValue to avoid memory leak
-          child: TextFormField(
-            decoration: InputDecoration(labelText: field.name),
-            keyboardType: TextInputType.number,
-            initialValue: currentValue?.toString() ?? '',
-            onChanged: (value) {
-              _additionalFieldValues[field.id] = int.tryParse(value) ?? 0;
-              _markChanged();
-            },
-          ),
-        );
-
-      case 'boolean':
-        return Padding(
-          padding: const EdgeInsets.only(bottom: AppDimensions.paddingM),
-          child: SwitchListTile(
-            contentPadding: EdgeInsets.zero,
-            title: Text(field.name),
-            value: currentValue == true,
-            onChanged: (value) {
-              setState(() {
-                _additionalFieldValues[field.id] = value;
-              });
-              _markChanged();
-            },
-          ),
-        );
-
-      case 'date':
-        final dateValue = currentValue != null ? DateTime.tryParse(currentValue.toString()) : null;
-        return Padding(
-          padding: const EdgeInsets.only(bottom: AppDimensions.paddingM),
-          child: ListTile(
-            contentPadding: EdgeInsets.zero,
-            title: Text(field.name),
-            subtitle: Text(dateValue != null ? DateFormat('dd.MM.yyyy').format(dateValue) : 'Nicht angegeben'),
-            trailing: const Icon(Icons.calendar_today),
-            onTap: () async {
-              final date = await showDatePicker(
-                context: context,
-                initialDate: dateValue ?? DateTime.now(),
-                firstDate: DateTime(1900),
-                lastDate: DateTime(2100),
-              );
-              if (date != null) {
-                setState(() {
-                  _additionalFieldValues[field.id] = date.toIso8601String().split('T')[0];
-                });
-                _markChanged();
-              }
-            },
-          ),
-        );
-
-      case 'select':
-        final options = field.options ?? [];
-        return Padding(
-          padding: const EdgeInsets.only(bottom: AppDimensions.paddingM),
-          child: DropdownButtonFormField<String>(
-            decoration: InputDecoration(labelText: field.name),
-            value: options.contains(currentValue) ? currentValue?.toString() : (options.isNotEmpty ? options.first : null),
-            items: options.map((opt) => DropdownMenuItem(value: opt, child: Text(opt))).toList(),
-            onChanged: (value) {
-              setState(() {
-                _additionalFieldValues[field.id] = value;
-              });
-              _markChanged();
-            },
-          ),
-        );
-
-      default:
-        return const SizedBox.shrink();
-    }
-  }
-
-  Widget _buildHeader(Person person, AsyncValue<Map<String, dynamic>> statsAsync) {
-    return Container(
-      padding: const EdgeInsets.all(AppDimensions.paddingL),
-      decoration: BoxDecoration(
-        gradient: LinearGradient(
-          begin: Alignment.topCenter,
-          end: Alignment.bottomCenter,
-          colors: [
-            person.isCritical ? AppColors.danger : AppColors.primary,
-            (person.isCritical ? AppColors.danger : AppColors.primary).withValues(alpha: 0.7),
-          ],
-        ),
-      ),
-      child: Column(
-        children: [
-          Hero(
-            tag: 'person-${person.id}',
-            child: CircleAvatar(
-              radius: 50,
-              backgroundColor: Colors.white,
-              backgroundImage: person.img != null && !person.img!.contains('.svg')
-                  ? NetworkImage(person.img!)
-                  : null,
-              child: person.img == null || person.img!.contains('.svg')
-                  ? Text(person.initials, style: const TextStyle(fontSize: 36, fontWeight: FontWeight.bold, color: AppColors.primary))
-                  : null,
-            ),
-          ),
-          const SizedBox(height: AppDimensions.paddingM),
-          if (person.groupName != null)
-            Container(
-              padding: const EdgeInsets.symmetric(horizontal: AppDimensions.paddingM, vertical: AppDimensions.paddingXS),
-              decoration: BoxDecoration(color: Colors.white.withValues(alpha: 0.2), borderRadius: BorderRadius.circular(AppDimensions.borderRadiusS)),
-              child: Text(person.groupName!, style: const TextStyle(color: Colors.white, fontWeight: FontWeight.w500)),
-            ),
-          const SizedBox(height: AppDimensions.paddingM),
-          statsAsync.when(
-            loading: () => const SizedBox.shrink(),
-            error: (_, __) => const SizedBox.shrink(),
-            data: (stats) => Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                _StatItem(
-                  value: '${stats['percentage']}%',
-                  label: stats['lateCount'] > 0 ? 'Anwesenheit (${stats['lateCount']}x zu spät)' : 'Anwesenheit',
-                  color: stats['percentage'] >= 75 ? AppColors.success : stats['percentage'] >= 50 ? AppColors.warning : AppColors.danger,
-                ),
-                Container(width: 1, height: 40, margin: const EdgeInsets.symmetric(horizontal: AppDimensions.paddingL), color: Colors.white.withValues(alpha: 0.3)),
-                _StatItem(value: '${stats['attended']}/${stats['total']}', label: 'Termine', color: Colors.white),
-              ],
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildLateWarningCard(Person person, AsyncValue<Map<String, dynamic>> statsAsync) {
-    return statsAsync.when(
-      loading: () => const SizedBox.shrink(),
-      error: (_, __) => const SizedBox.shrink(),
-      data: (stats) {
-        final lateCount = stats['lateCount'] as int? ?? 0;
-        // Get threshold from tenant's critical rules - find first rule for late status (3 = late)
-        final tenant = ref.watch(currentTenantProvider);
-        // Default threshold of 3
-        int threshold = 3;
-        // Try to find a late-specific rule
-        if (tenant?.criticalRules != null) {
-          for (final rule in tenant!.criticalRules!) {
-            // Status 3 = late
-            if (rule.statuses.contains(3)) {
-              threshold = rule.thresholdValue;
-              break;
-            }
-          }
-        }
-
-        if (lateCount < threshold) return const SizedBox.shrink();
-
-        return Card(
-          margin: const EdgeInsets.all(AppDimensions.paddingM),
-          color: Colors.orange.shade50,
-          child: ListTile(
-            leading: Container(
-              padding: const EdgeInsets.all(8),
-              decoration: BoxDecoration(
-                color: Colors.orange.shade100,
-                borderRadius: BorderRadius.circular(8),
-              ),
-              child: const Icon(Icons.schedule, color: Colors.orange),
-            ),
-            title: const Text(
-              'Häufige Verspätungen',
-              style: TextStyle(fontWeight: FontWeight.w600),
-            ),
-            subtitle: Text(
-              '$lateCount× unentschuldigt zu spät (Schwelle: $threshold)',
-              style: TextStyle(color: Colors.orange.shade800),
-            ),
-            trailing: FilledButton.tonal(
-              onPressed: _resetLateCount,
-              child: const Text('Zurücksetzen'),
-            ),
-          ),
-        );
-      },
-    );
-  }
-
-  Widget _buildProblemfallContent(Person person) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        if (person.criticalReason != null && person.criticalReason!.isNotEmpty) ...[
-          Container(
-            width: double.infinity,
-            padding: const EdgeInsets.all(AppDimensions.paddingM),
-            decoration: BoxDecoration(
-              color: AppColors.danger.withValues(alpha: 0.1),
-              borderRadius: BorderRadius.circular(AppDimensions.borderRadiusS),
-            ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                const Text(
-                  'Grund',
-                  style: TextStyle(
-                    fontSize: 12,
-                    fontWeight: FontWeight.w600,
-                    color: AppColors.danger,
-                  ),
-                ),
-                const SizedBox(height: AppDimensions.paddingXS),
-                Text(
-                  person.criticalReason!,
-                  style: const TextStyle(color: AppColors.dark),
-                ),
-              ],
-            ),
-          ),
-          const SizedBox(height: AppDimensions.paddingM),
-        ],
-        SwitchListTile(
-          contentPadding: EdgeInsets.zero,
-          title: const Text('Mit Person gesprochen'),
-          subtitle: const Text('Bestätigen, dass das Problem besprochen wurde'),
-          value: _problemSolved,
-          onChanged: (value) => setState(() => _problemSolved = value),
-          activeColor: AppColors.success,
-        ),
-        if (_problemSolved) ...[
-          const SizedBox(height: AppDimensions.paddingM),
-          TextField(
-            decoration: const InputDecoration(
-              labelText: 'Anmerkungen (optional)',
-              hintText: 'Was wurde besprochen?',
-              border: OutlineInputBorder(),
-            ),
-            maxLines: 3,
-            onChanged: (value) => _problemNotes = value,
-          ),
-          const SizedBox(height: AppDimensions.paddingM),
-          SizedBox(
-            width: double.infinity,
-            child: FilledButton.icon(
-              onPressed: _resolveProblem,
-              icon: const Icon(Icons.check_circle),
-              label: const Text('Problem als gelöst markieren'),
-              style: FilledButton.styleFrom(
-                backgroundColor: AppColors.success,
-              ),
-            ),
-          ),
-        ],
-      ],
-    );
-  }
-
-  bool _hasStatusBadges(Person person) => person.archived || person.paused || person.isCritical || person.pending || person.isLeader;
-
-  List<Widget> _buildStatusBadges(Person person) {
-    final badges = <Widget>[];
-    if (person.archived) badges.add(_StatusBadge(label: 'Archiviert', color: AppColors.medium, icon: Icons.archive));
-    if (person.paused) badges.add(_StatusBadge(label: person.pausedUntil != null ? 'Pausiert bis ${_formatDate(person.pausedUntil!)}' : 'Pausiert', color: AppColors.warning, icon: Icons.pause_circle));
-    if (person.isCritical) badges.add(_StatusBadge(label: 'Kritisch', color: AppColors.danger, icon: Icons.warning));
-    if (person.pending) badges.add(_StatusBadge(label: 'Ausstehend', color: AppColors.info, icon: Icons.hourglass_empty));
-    if (person.isLeader) badges.add(_StatusBadge(label: 'Stimmführer', color: AppColors.success, icon: Icons.star));
-    return badges;
-  }
-
-  Widget _buildNameSection(Person person) {
-    return Card(
-      margin: const EdgeInsets.all(AppDimensions.paddingM),
-      child: Padding(
-        padding: const EdgeInsets.all(AppDimensions.paddingM),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                Expanded(child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-                  const Text('Vorname', style: TextStyle(fontSize: 12, color: AppColors.medium)),
-                  Text(person.firstName, style: const TextStyle(fontSize: 16)),
-                ])),
-                Expanded(child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-                  const Text('Nachname', style: TextStyle(fontSize: 12, color: AppColors.medium)),
-                  Text(person.lastName, style: const TextStyle(fontSize: 16)),
-                ])),
-              ],
-            ),
-            if (person.notes != null && person.notes!.isNotEmpty) ...[
-              const SizedBox(height: AppDimensions.paddingM),
-              const Text('Notizen', style: TextStyle(fontSize: 12, color: AppColors.medium)),
-              const SizedBox(height: AppDimensions.paddingXS),
-              Text(person.notes!),
-            ],
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildAccordionSection({required String title, required bool isExpanded, required VoidCallback onToggle, required Widget child}) {
-    return Card(
-      margin: const EdgeInsets.symmetric(horizontal: AppDimensions.paddingM, vertical: AppDimensions.paddingXS),
-      child: Column(
-        children: [
-          ListTile(title: Text(title, style: const TextStyle(fontWeight: FontWeight.w600)), trailing: Icon(isExpanded ? Icons.expand_less : Icons.expand_more), onTap: onToggle),
-          if (isExpanded) Padding(padding: const EdgeInsets.fromLTRB(AppDimensions.paddingM, 0, AppDimensions.paddingM, AppDimensions.paddingM), child: child),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildAllgemeinContent(Person person) {
-    final tenant = ref.watch(currentTenantProvider);
-    final extraFields = tenant?.additionalFields ?? [];
-    final additionalFieldValues = person.additionalFields ?? {};
-
-    return Column(
-      children: [
-        _InfoRow(icon: Icons.group, label: 'Gruppe', value: person.groupName ?? 'Nicht zugewiesen'),
-        if (person.phone != null && person.phone!.isNotEmpty)
-          _InfoRow(icon: Icons.phone, label: 'Telefon', value: person.phone!, onTap: () => _launchUrl('tel:${person.phone}')),
-        if (person.birthday != null && person.birthday!.isNotEmpty)
-          _InfoRow(icon: Icons.cake, label: 'Geburtsdatum', value: _formatDate(person.birthday!), highlight: !person.correctBirthday, highlightColor: AppColors.warning),
-        if (person.playsSince != null && person.playsSince!.isNotEmpty)
-          _InfoRow(icon: Icons.music_note, label: 'Spielt auf dem Instrument seit', value: _formatDate(person.playsSince!)),
-        if (person.joined != null && person.joined!.isNotEmpty)
-          _InfoRow(icon: Icons.login, label: 'Beigetreten am', value: _formatDate(person.joined!)),
-        if (person.hasTeacher)
-          _InfoRow(icon: Icons.school, label: 'Spielt beim Lehrer', value: person.teacherName ?? 'Ja'),
-        _InfoRow(icon: Icons.star, label: 'Stimmführer', value: person.isLeader ? 'Ja' : 'Nein'),
-        if (person.otherExercise != null && person.otherExercise!.isNotEmpty)
-          _InfoRow(icon: Icons.work, label: 'Sonstige Dienste', value: person.otherExercise!),
-
-        // Extra Fields Section
-        if (extraFields.isNotEmpty) ...[
-          const Divider(height: 32),
-          Text(
-            'Zusatzfelder',
-            style: Theme.of(context).textTheme.titleSmall?.copyWith(
-              fontWeight: FontWeight.w600,
-              color: AppColors.primary,
-            ),
-          ),
-          const SizedBox(height: AppDimensions.paddingS),
-          ...extraFields.map((field) {
-            final value = additionalFieldValues[field.id];
-            String displayValue = _formatExtraFieldValue(field, value);
-            return _InfoRow(
-              icon: _getExtraFieldIcon(field.type),
-              label: field.name,
-              value: displayValue,
-            );
-          }),
-        ],
-      ],
-    );
-  }
-
-  IconData _getExtraFieldIcon(String type) {
-    switch (type) {
-      case 'text':
-        return Icons.text_fields;
-      case 'textarea':
-        return Icons.notes;
-      case 'number':
-        return Icons.numbers;
-      case 'date':
-        return Icons.calendar_today;
-      case 'boolean':
-        return Icons.toggle_on;
-      case 'select':
-        return Icons.list;
-      default:
-        return Icons.text_fields;
-    }
-  }
-
-  String _formatExtraFieldValue(ExtraField field, dynamic value) {
-    if (value == null) {
-      return 'Nicht angegeben';
-    }
-
-    switch (field.type) {
-      case 'boolean':
-        return value == true ? 'Ja' : 'Nein';
-      case 'date':
-        final date = DateTime.tryParse(value.toString());
-        if (date != null) {
-          return DateFormat('dd.MM.yyyy').format(date);
-        }
-        return value.toString();
-      default:
-        return value.toString();
-    }
-  }
-
-  Widget _buildAccountContent(Person person) {
-    final tenant = ref.watch(currentTenantProvider);
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        _InfoRow(
-          icon: Icons.email,
-          label: 'E-Mail',
-          value: person.email ?? 'Nicht angegeben',
-          onTap: person.email != null ? () => _launchUrl('mailto:${person.email}') : null,
-        ),
-        if (person.appId != null) ...[
-          _InfoRow(icon: Icons.badge, label: 'Account', value: 'Verknüpft'),
-          const SizedBox(height: AppDimensions.paddingM),
-          // Role selector
-          _buildRoleSelector(person, tenant),
-          const SizedBox(height: AppDimensions.paddingM),
-          // Unlink account button
-          OutlinedButton.icon(
-            onPressed: () => _showUnlinkAccountDialog(person),
-            icon: const Icon(Icons.link_off, color: AppColors.danger),
-            label: const Text('Account-Verknüpfung aufheben'),
-            style: OutlinedButton.styleFrom(foregroundColor: AppColors.danger),
-          ),
-        ],
-        // BL-003: Account creation not implemented - show info instead of non-working button
-        if (person.appId == null && person.email != null) ...[
-          const SizedBox(height: AppDimensions.paddingM),
-          Container(
-            padding: const EdgeInsets.all(AppDimensions.paddingM),
-            decoration: BoxDecoration(
-              color: AppColors.primary.withValues(alpha: 0.1),
-              borderRadius: BorderRadius.circular(AppDimensions.borderRadiusS),
-            ),
-            child: const Row(
-              children: [
-                Icon(Icons.info_outline, color: AppColors.primary, size: 20),
-                SizedBox(width: AppDimensions.paddingS),
-                Expanded(
-                  child: Text(
-                    'Account-Erstellung ist über die Web-Verwaltung möglich.',
-                    style: TextStyle(fontSize: 13, color: AppColors.dark),
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ],
-        if (person.appId == null && person.email == null)
-          Container(
-            padding: const EdgeInsets.all(AppDimensions.paddingM),
-            decoration: BoxDecoration(
-              color: AppColors.warning.withValues(alpha: 0.1),
-              borderRadius: BorderRadius.circular(AppDimensions.borderRadiusS),
-            ),
-            child: const Row(
-              children: [
-                Icon(Icons.info_outline, color: AppColors.warning),
-                SizedBox(width: AppDimensions.paddingS),
-                Expanded(
-                  child: Text(
-                    'Um einen Account zu erstellen, muss eine E-Mail-Adresse hinterlegt werden.',
-                    style: TextStyle(fontSize: 13),
-                  ),
-                ),
-              ],
-            ),
-          ),
-      ],
-    );
-  }
-
-  Widget _buildRoleSelector(Person person, Tenant? tenant) {
-    // RT-001: Safe null checks - store in local variables after check
-    final appId = person.appId;
-    final tenantId = tenant?.id;
-    if (appId == null || tenantId == null) {
-      return const SizedBox.shrink();
-    }
-
-    // Available roles for selection
-    final availableRoles = [
-      Role.player,
-      Role.helper,
-      Role.viewer,
-      Role.responsible,
-      Role.admin,
-    ];
-
-    // FN-005: Use state-based role instead of FutureBuilder
-    if (_isLoadingRole) {
-      return const Center(child: CircularProgressIndicator());
-    }
-
-    final currentRole = _userRole ?? Role.player;
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        const Text(
-          'Rolle',
-          style: TextStyle(fontSize: 12, color: AppColors.medium),
-        ),
-        const SizedBox(height: AppDimensions.paddingXS),
-        DropdownButtonFormField<Role>(
-          value: currentRole,
-          decoration: const InputDecoration(
-            border: OutlineInputBorder(),
-            contentPadding: EdgeInsets.symmetric(
-              horizontal: AppDimensions.paddingM,
-              vertical: AppDimensions.paddingS,
-            ),
-          ),
-          items: availableRoles.map((role) {
-            return DropdownMenuItem(
-              value: role,
-              child: Row(
-                children: [
-                  Icon(_getRoleIcon(role), size: 20, color: AppColors.primary),
-                  const SizedBox(width: AppDimensions.paddingS),
-                  Text(_getRoleLabel(role)),
-                ],
-              ),
-            );
-          }).toList(),
-          onChanged: (newRole) async {
-            if (newRole != null && newRole != currentRole) {
-              // RT-001: appId and tenantId are already validated above
-              await _updateUserRole(appId, tenantId, newRole);
-            }
-          },
-        ),
-      ],
-    );
-  }
-
-  Future<Role?> _getUserRole(String userId, int tenantId) async {
-    final supabase = ref.read(supabaseClientProvider);
-    try {
-      final response = await supabase
-          .from('tenantUsers')
-          .select('role')
-          .eq('userId', userId)
-          .eq('tenantId', tenantId)
-          .maybeSingle();
-
-      if (response == null) return null;
-      // RT-004: Safe type cast with fallback to Role.none (99)
-      return Role.fromValue(response['role'] as int? ?? 99);
-    } catch (e) {
-      return null;
-    }
-  }
-
-  Future<void> _updateUserRole(String userId, int tenantId, Role newRole) async {
-    // Authorization check - only conductors can change roles
+  Future<void> _updateUserRole(Role newRole) async {
     final currentUserRole = ref.read(currentRoleProvider);
     if (!currentUserRole.isConductor) {
       if (mounted) {
@@ -2031,20 +940,24 @@ class _PersonDetailContentState extends ConsumerState<_PersonDetailContent> {
     }
 
     final supabase = ref.read(supabaseClientProvider);
+    final tenant = ref.read(currentTenantProvider);
+    final appId = widget.person.appId;
+    final tenantId = tenant?.id;
+
+    if (appId == null || tenantId == null) return;
 
     try {
       await supabase
           .from('tenantUsers')
           .update({'role': newRole.value})
-          .eq('userId', userId)
+          .eq('userId', appId)
           .eq('tenantId', tenantId);
 
-      // FN-005: Update local state immediately after successful update
       if (mounted) {
         setState(() => _userRole = newRole);
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text('Rolle auf "${_getRoleLabel(newRole)}" geändert'),
+            content: Text('Rolle geändert'),
             backgroundColor: AppColors.success,
           ),
         );
@@ -2058,46 +971,13 @@ class _PersonDetailContentState extends ConsumerState<_PersonDetailContent> {
     }
   }
 
-  String _getRoleLabel(Role role) {
-    return switch (role) {
-      Role.admin => 'Dirigent (Admin)',
-      Role.responsible => 'Verantwortlicher',
-      Role.helper => 'Helfer',
-      Role.viewer => 'Beobachter',
-      Role.player => 'Mitglied',
-      Role.voiceLeader => 'Stimmführer',
-      Role.voiceLeaderHelper => 'Stimmführer-Helfer',
-      Role.parent => 'Eltern',
-      Role.applicant => 'Bewerber',
-      Role.none => 'Keine Rolle',
-    };
-  }
-
-  IconData _getRoleIcon(Role role) {
-    return switch (role) {
-      Role.admin => Icons.admin_panel_settings,
-      Role.responsible => Icons.manage_accounts,
-      Role.helper => Icons.handshake,
-      Role.viewer => Icons.visibility,
-      Role.player => Icons.person,
-      Role.voiceLeader => Icons.record_voice_over,
-      Role.voiceLeaderHelper => Icons.support_agent,
-      Role.parent => Icons.family_restroom,
-      Role.applicant => Icons.pending,
-      Role.none => Icons.person_off,
-    };
-  }
-
-  // BL-003: Removed _showCreateAccountDialog and _createAccount as feature not implemented
-  // Account creation should be done via web admin panel
-
-  Future<void> _showUnlinkAccountDialog(Person person) async {
+  Future<void> _unlinkAccount() async {
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
         title: const Text('Account-Verknüpfung aufheben?'),
         content: Text(
-          'Die Account-Verknüpfung für ${person.fullName} wird aufgehoben. '
+          'Die Account-Verknüpfung für ${widget.person.fullName} wird aufgehoben. '
           'Die Person kann sich dann nicht mehr in der App anmelden.',
         ),
         actions: [
@@ -2114,13 +994,8 @@ class _PersonDetailContentState extends ConsumerState<_PersonDetailContent> {
       ),
     );
 
-    if (confirmed == true && mounted) {
-      await _unlinkAccount(person);
-    }
-  }
+    if (confirmed != true || !mounted) return;
 
-  Future<void> _unlinkAccount(Person person) async {
-    // Authorization check - only conductors can unlink accounts
     final currentUserRole = ref.read(currentRoleProvider);
     if (!currentUserRole.isConductor) {
       if (mounted) {
@@ -2135,13 +1010,12 @@ class _PersonDetailContentState extends ConsumerState<_PersonDetailContent> {
     }
 
     final notifier = ref.read(playerNotifierProvider.notifier);
-    final tenant = ref.read(currentTenantProvider);  // Use ref.read in async methods
+    final tenant = ref.read(currentTenantProvider);
+    final person = widget.person;
 
     try {
-      // Remove appId from player
       await notifier.unlinkAccount(person);
 
-      // Also remove from tenant_users if possible
       if (person.appId != null && tenant?.id != null) {
         final supabase = ref.read(supabaseClientProvider);
         await supabase
@@ -2170,235 +1044,126 @@ class _PersonDetailContentState extends ConsumerState<_PersonDetailContent> {
     }
   }
 
-  Widget _buildHistoryContent() {
-    final historyAsync = ref.watch(personHistoryProvider(widget.personId));
+  @override
+  Widget build(BuildContext context) {
+    final person = _draft;
     final statsAsync = ref.watch(personAttendanceStatsProvider(widget.personId));
-    
-    return historyAsync.when(
-      loading: () => const Center(child: Padding(padding: EdgeInsets.all(AppDimensions.paddingL), child: CircularProgressIndicator())),
-      error: (error, _) => Center(child: Text('Fehler: $error')),
-      data: (history) {
-        if (history.isEmpty) {
-          return const Padding(
-            padding: EdgeInsets.all(AppDimensions.paddingL),
-            child: Center(child: Column(children: [
-              Icon(Icons.history, size: 48, color: AppColors.medium),
-              SizedBox(height: AppDimensions.paddingS),
-              Text('Keine Historie vorhanden'),
-            ])),
-          );
-        }
-        
-        return Column(
-          children: [
-            // Durchschnitt Row (like Ionic)
-            statsAsync.when(
-              loading: () => const SizedBox.shrink(),
-              error: (_, __) => const SizedBox.shrink(),
-              data: (stats) {
-                final percentage = stats['percentage'] as int;
-                final lateCount = stats['lateCount'] as int;
-                final lateText = lateCount > 0 ? ' (${lateCount}x zu spät)' : '';
-                Color badgeColor = percentage >= 75 ? AppColors.success : percentage >= 50 ? AppColors.warning : AppColors.danger;
-                return Container(
-                  padding: const EdgeInsets.symmetric(vertical: AppDimensions.paddingM),
-                  decoration: BoxDecoration(
-                    border: Border(bottom: BorderSide(color: Colors.grey.shade200)),
-                  ),
-                  child: Row(
-                    children: [
-                      Expanded(
-                        child: Text(
-                          'Durchschnitt$lateText',
-                          style: const TextStyle(fontSize: 15, fontWeight: FontWeight.w500),
-                        ),
-                      ),
-                      Container(
-                        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
-                        decoration: BoxDecoration(
-                          color: badgeColor,
-                          borderRadius: BorderRadius.circular(4),
-                        ),
-                        child: Text(
-                          '$percentage%',
-                          style: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold, fontSize: 14),
-                        ),
-                      ),
-                    ],
-                  ),
-                );
-              },
-            ),
-            
-            // History items
-            ...history.take(20).map((item) {
-              final date = DateTime.tryParse(item['date'] ?? '');
-              final type = item['type'] as int?;
-              final text = item['text']?.toString() ?? '';
-              final meetingName = item['meetingName']?.toString();
-              final notes = item['notes']?.toString();
-              
-              // For attendance items, use meeting name if available
-              String displayTitle = '';
-              if (type == 4) {
-                // Attendance entry - show meeting name if present
-                displayTitle = meetingName ?? '';
-              } else {
-                // Other history types
-                switch (type) {
-                  case 0:
-                    displayTitle = 'Pausiert';
-                    break;
-                  case 5:
-                    displayTitle = 'Wieder aktiv';
-                    break;
-                  case 6:
-                    displayTitle = 'Gruppenwechsel';
-                    break;
-                  case 7:
-                    displayTitle = 'Archiviert';
-                    break;
-                  default:
-                    displayTitle = item['title']?.toString() ?? 'Eintrag';
-                }
-              }
-              
-              // Build badge for attendance status
-              String? badgeText;
-              Color? badgeColor;
-              if (type == 4) {
-                // Attendance badge - X=present, L=late, E=excused, A=absent
-                if (text == 'X') {
-                  badgeText = '✓';
-                  badgeColor = AppColors.success;
-                } else if (text == 'L') {
-                  badgeText = 'L';
-                  badgeColor = AppColors.tertiary;
-                } else if (text == 'E') {
-                  badgeText = 'E';
-                  badgeColor = AppColors.warning;
-                } else if (text == 'N') {
-                  badgeText = 'N';
-                  badgeColor = AppColors.medium;
-                } else {
-                  badgeText = 'A';
-                  badgeColor = AppColors.danger;
-                }
-              }
-              
-              // Format: "DD.MM.YYYY" or "DD.MM.YYYY | Meeting Name"
-              final dateStr = date != null ? DateFormat('dd.MM.yyyy').format(date) : '';
-              final titleStr = displayTitle.isNotEmpty ? '$dateStr | $displayTitle' : dateStr;
-              
-              return Container(
-                padding: const EdgeInsets.symmetric(vertical: AppDimensions.paddingM),
-                decoration: BoxDecoration(
-                  border: Border(bottom: BorderSide(color: Colors.grey.shade100)),
-                ),
-                child: Row(
-                  children: [
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(titleStr, style: const TextStyle(fontSize: 15)),
-                          if (notes != null && notes.isNotEmpty)
-                            Padding(
-                              padding: const EdgeInsets.only(top: 2),
-                              child: Text(notes, style: TextStyle(fontSize: 12, color: Colors.grey.shade600)),
-                            ),
-                          if (type != 4 && text.isNotEmpty)
-                            Padding(
-                              padding: const EdgeInsets.only(top: 2),
-                              child: Text(text, style: TextStyle(fontSize: 12, color: Colors.grey.shade600)),
-                            ),
-                        ],
-                      ),
-                    ),
-                    if (badgeText != null)
-                      Container(
-                        width: 32,
-                        height: 32,
-                        decoration: BoxDecoration(
-                          color: badgeColor,
-                          borderRadius: BorderRadius.circular(4),
-                        ),
-                        child: Center(
-                          child: Text(
-                            badgeText,
-                            style: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold, fontSize: 16),
-                          ),
-                        ),
-                      ),
-                  ],
-                ),
-              );
-            }),
-          ],
+    final historyAsync = ref.watch(personHistoryProvider(widget.personId));
+    final canEdit = ref.watch(currentRoleProvider).canEdit;
+
+    return PopScope(
+      canPop: !_hasChanges,
+      onPopInvokedWithResult: (didPop, result) async {
+        if (didPop) return;
+        final shouldDiscard = await showDialog<bool>(
+          context: context,
+          builder: (context) => AlertDialog(
+            title: const Text('Änderungen verwerfen?'),
+            content: const Text('Du hast ungespeicherte Änderungen. Möchtest du diese verwerfen?'),
+            actions: [
+              TextButton(onPressed: () => Navigator.pop(context, false), child: const Text('Abbrechen')),
+              FilledButton(onPressed: () => Navigator.pop(context, true), child: const Text('Verwerfen')),
+            ],
+          ),
         );
+        if (shouldDiscard == true && context.mounted) {
+          Navigator.of(context).pop();
+        }
       },
-    );
-  }
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(person.fullName),
+          backgroundColor: person.isCritical ? AppColors.danger : null,
+          actions: [
+            if (canEdit)
+              IconButton(
+                icon: const Icon(Icons.more_vert),
+                tooltip: 'Mehr',
+                onPressed: _showMoreActions,
+              ),
+          ],
+        ),
+        body: ListView(
+          padding: const EdgeInsets.only(bottom: 100),
+          children: [
+            // Header with avatar and stats
+            PersonHeader(person: person, statsAsync: statsAsync),
 
-  String _formatDate(String dateString) {
-    final date = DateTime.tryParse(dateString);
-    if (date == null) return dateString;
-    return DateFormat('dd.MM.yyyy').format(date);
-  }
-}
+            // Status badges
+            PersonStatusBadges(person: person),
 
-class _StatItem extends StatelessWidget {
-  const _StatItem({required this.value, required this.label, required this.color});
-  final String value;
-  final String label;
-  final Color color;
-  @override
-  Widget build(BuildContext context) {
-    return Column(children: [
-      Text(value, style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold, color: color)),
-      Text(label, style: const TextStyle(fontSize: 12, color: Colors.white70)),
-    ]);
-  }
-}
+            // Late Warning Card
+            LateWarningCard(
+              person: person,
+              statsAsync: statsAsync,
+              onResetLateCount: _resetLateCount,
+            ),
 
-class _StatusBadge extends StatelessWidget {
-  const _StatusBadge({required this.label, required this.color, required this.icon});
-  final String label;
-  final Color color;
-  final IconData icon;
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: AppDimensions.paddingS, vertical: AppDimensions.paddingXS),
-      decoration: BoxDecoration(color: color.withValues(alpha: 0.15), borderRadius: BorderRadius.circular(AppDimensions.borderRadiusS), border: Border.all(color: color.withValues(alpha: 0.3))),
-      child: Row(mainAxisSize: MainAxisSize.min, children: [
-        Icon(icon, size: 16, color: color),
-        const SizedBox(width: 4),
-        Text(label, style: TextStyle(color: color, fontSize: 12, fontWeight: FontWeight.w500)),
-      ]),
-    );
-  }
-}
+            // Problem Person Accordion
+            ProblemfallAccordion(
+              person: person,
+              isExpanded: _showProblemfall,
+              onToggle: () => setState(() => _showProblemfall = !_showProblemfall),
+              problemSolved: _problemSolved,
+              onProblemSolvedChanged: (v) => setState(() => _problemSolved = v),
+              problemNotes: _problemNotes,
+              onProblemNotesChanged: (v) => _problemNotes = v,
+              onResolveProblem: _resolveProblem,
+            ),
 
-class _InfoRow extends StatelessWidget {
-  const _InfoRow({required this.icon, required this.label, required this.value, this.onTap, this.highlight = false, this.highlightColor});
-  final IconData icon;
-  final String label;
-  final String value;
-  final VoidCallback? onTap;
-  final bool highlight;
-  final Color? highlightColor;
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      decoration: highlight ? BoxDecoration(color: (highlightColor ?? AppColors.warning).withValues(alpha: 0.1), borderRadius: BorderRadius.circular(AppDimensions.borderRadiusS)) : null,
-      child: ListTile(
-        contentPadding: EdgeInsets.zero,
-        leading: Icon(icon, color: AppColors.primary, size: 20),
-        title: Text(label, style: const TextStyle(fontSize: 12, color: AppColors.medium)),
-        subtitle: Text(value, style: const TextStyle(fontSize: 14)),
-        trailing: onTap != null ? const Icon(Icons.chevron_right, size: 20) : null,
-        onTap: onTap,
+            // Allgemein Accordion with inline editing
+            AllgemeinAccordion(
+              person: person,
+              isExpanded: _showAllgemein,
+              onToggle: () => setState(() => _showAllgemein = !_showAllgemein),
+              onFieldChanged: _onFieldChanged,
+              canEdit: canEdit,
+              selectedGroupId: _selectedGroupId,
+              selectedTeacherId: _selectedTeacherId,
+              selectedShiftId: _selectedShiftId,
+              selectedShiftName: _selectedShiftName,
+              shiftStart: _shiftStart,
+              selectedParentId: _selectedParentId,
+              isLeader: _isLeader,
+              hasTeacher: _hasTeacher,
+              additionalFieldValues: _additionalFieldValues,
+            ),
+
+            // Account Accordion
+            AccountAccordion(
+              person: person,
+              isExpanded: _showAccount,
+              onToggle: () => setState(() => _showAccount = !_showAccount),
+              userRole: _userRole,
+              isLoadingRole: _isLoadingRole,
+              onRoleChanged: _updateUserRole,
+              onUnlinkAccount: _unlinkAccount,
+              canEdit: canEdit,
+            ),
+
+            // Historie Accordion
+            HistorieAccordion(
+              isExpanded: _showHistorie,
+              onToggle: () => setState(() => _showHistorie = !_showHistorie),
+              historyAsync: historyAsync,
+              statsAsync: statsAsync,
+            ),
+          ],
+        ),
+        floatingActionButton: _hasChanges
+            ? FloatingActionButton.extended(
+                onPressed: _isSaving ? null : _saveChanges,
+                icon: _isSaving
+                    ? const SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white),
+                      )
+                    : const Icon(Icons.save),
+                label: Text(_isSaving ? 'Speichern...' : 'Speichern'),
+                backgroundColor: AppColors.primary,
+              )
+            : null,
       ),
     );
   }

--- a/lib/features/people/presentation/widgets/person_detail/account_accordion.dart
+++ b/lib/features/people/presentation/widgets/person_detail/account_accordion.dart
@@ -1,0 +1,255 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../../../../core/constants/app_constants.dart';
+import '../../../../../core/constants/enums.dart';
+import '../../../../../core/providers/tenant_providers.dart';
+import '../../../../../core/theme/app_colors.dart';
+import '../../../../../data/models/person/person.dart';
+import '../../../../../shared/widgets/editable/editable_info_row.dart';
+
+/// Accordion section displaying account information.
+class AccountAccordion extends ConsumerWidget {
+  const AccountAccordion({
+    super.key,
+    required this.person,
+    required this.isExpanded,
+    required this.onToggle,
+    required this.userRole,
+    required this.isLoadingRole,
+    required this.onRoleChanged,
+    required this.onUnlinkAccount,
+    required this.canEdit,
+  });
+
+  final Person person;
+  final bool isExpanded;
+  final VoidCallback onToggle;
+  final Role? userRole;
+  final bool isLoadingRole;
+  final ValueChanged<Role> onRoleChanged;
+  final VoidCallback onUnlinkAccount;
+  final bool canEdit;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Only show if person has email or appId
+    if (person.email == null && person.appId == null) {
+      return const SizedBox.shrink();
+    }
+
+    return Card(
+      margin: const EdgeInsets.symmetric(
+        horizontal: AppDimensions.paddingM,
+        vertical: AppDimensions.paddingXS,
+      ),
+      child: Column(
+        children: [
+          ListTile(
+            title: const Text(
+              'Account',
+              style: TextStyle(fontWeight: FontWeight.w600),
+            ),
+            trailing: Icon(isExpanded ? Icons.expand_less : Icons.expand_more),
+            onTap: onToggle,
+          ),
+          if (isExpanded)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(
+                AppDimensions.paddingM,
+                0,
+                AppDimensions.paddingM,
+                AppDimensions.paddingM,
+              ),
+              child: _buildContent(context, ref),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildContent(BuildContext context, WidgetRef ref) {
+    final tenant = ref.watch(currentTenantProvider);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Email
+        InfoRow(
+          icon: Icons.email,
+          label: 'E-Mail',
+          value: person.email ?? 'Nicht angegeben',
+          onTap: person.email != null
+              ? () => _launchEmail(person.email!)
+              : null,
+        ),
+
+        // Account linked status
+        if (person.appId != null) ...[
+          const InfoRow(
+            icon: Icons.badge,
+            label: 'Account',
+            value: 'Verknüpft',
+          ),
+          const SizedBox(height: AppDimensions.paddingM),
+
+          // Role selector
+          _buildRoleSelector(context, tenant?.id),
+          const SizedBox(height: AppDimensions.paddingM),
+
+          // Unlink button
+          if (canEdit)
+            OutlinedButton.icon(
+              onPressed: onUnlinkAccount,
+              icon: const Icon(Icons.link_off, color: AppColors.danger),
+              label: const Text('Account-Verknüpfung aufheben'),
+              style: OutlinedButton.styleFrom(foregroundColor: AppColors.danger),
+            ),
+        ],
+
+        // Info for persons without account
+        if (person.appId == null && person.email != null) ...[
+          const SizedBox(height: AppDimensions.paddingM),
+          Container(
+            padding: const EdgeInsets.all(AppDimensions.paddingM),
+            decoration: BoxDecoration(
+              color: AppColors.primary.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(AppDimensions.borderRadiusS),
+            ),
+            child: const Row(
+              children: [
+                Icon(Icons.info_outline, color: AppColors.primary, size: 20),
+                SizedBox(width: AppDimensions.paddingS),
+                Expanded(
+                  child: Text(
+                    'Account-Erstellung ist über die Web-Verwaltung möglich.',
+                    style: TextStyle(fontSize: 13, color: AppColors.dark),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+
+        if (person.appId == null && person.email == null)
+          Container(
+            padding: const EdgeInsets.all(AppDimensions.paddingM),
+            decoration: BoxDecoration(
+              color: AppColors.warning.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(AppDimensions.borderRadiusS),
+            ),
+            child: const Row(
+              children: [
+                Icon(Icons.info_outline, color: AppColors.warning),
+                SizedBox(width: AppDimensions.paddingS),
+                Expanded(
+                  child: Text(
+                    'Um einen Account zu erstellen, muss eine E-Mail-Adresse hinterlegt werden.',
+                    style: TextStyle(fontSize: 13),
+                  ),
+                ),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildRoleSelector(BuildContext context, int? tenantId) {
+    if (person.appId == null || tenantId == null) {
+      return const SizedBox.shrink();
+    }
+
+    final availableRoles = [
+      Role.player,
+      Role.helper,
+      Role.viewer,
+      Role.responsible,
+      Role.admin,
+    ];
+
+    if (isLoadingRole) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    final currentRole = userRole ?? Role.player;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'Rolle',
+          style: TextStyle(fontSize: 12, color: AppColors.medium),
+        ),
+        const SizedBox(height: AppDimensions.paddingXS),
+        DropdownButtonFormField<Role>(
+          value: currentRole,
+          decoration: const InputDecoration(
+            border: OutlineInputBorder(),
+            contentPadding: EdgeInsets.symmetric(
+              horizontal: AppDimensions.paddingM,
+              vertical: AppDimensions.paddingS,
+            ),
+          ),
+          items: availableRoles.map((role) {
+            return DropdownMenuItem(
+              value: role,
+              child: Row(
+                children: [
+                  Icon(_getRoleIcon(role), size: 20, color: AppColors.primary),
+                  const SizedBox(width: AppDimensions.paddingS),
+                  Text(_getRoleLabel(role)),
+                ],
+              ),
+            );
+          }).toList(),
+          onChanged: canEdit
+              ? (newRole) {
+                  if (newRole != null && newRole != currentRole) {
+                    onRoleChanged(newRole);
+                  }
+                }
+              : null,
+        ),
+      ],
+    );
+  }
+
+  Future<void> _launchEmail(String email) async {
+    final uri = Uri.parse('mailto:$email');
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri);
+    }
+  }
+
+  String _getRoleLabel(Role role) {
+    return switch (role) {
+      Role.admin => 'Dirigent (Admin)',
+      Role.responsible => 'Verantwortlicher',
+      Role.helper => 'Helfer',
+      Role.viewer => 'Beobachter',
+      Role.player => 'Mitglied',
+      Role.voiceLeader => 'Stimmführer',
+      Role.voiceLeaderHelper => 'Stimmführer-Helfer',
+      Role.parent => 'Eltern',
+      Role.applicant => 'Bewerber',
+      Role.none => 'Keine Rolle',
+    };
+  }
+
+  IconData _getRoleIcon(Role role) {
+    return switch (role) {
+      Role.admin => Icons.admin_panel_settings,
+      Role.responsible => Icons.manage_accounts,
+      Role.helper => Icons.handshake,
+      Role.viewer => Icons.visibility,
+      Role.player => Icons.person,
+      Role.voiceLeader => Icons.record_voice_over,
+      Role.voiceLeaderHelper => Icons.support_agent,
+      Role.parent => Icons.family_restroom,
+      Role.applicant => Icons.pending,
+      Role.none => Icons.person_off,
+    };
+  }
+}

--- a/lib/features/people/presentation/widgets/person_detail/allgemein_accordion.dart
+++ b/lib/features/people/presentation/widgets/person_detail/allgemein_accordion.dart
@@ -1,0 +1,761 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+
+import '../../../../../core/constants/app_constants.dart';
+import '../../../../../core/providers/group_providers.dart';
+import '../../../../../core/providers/parent_providers.dart';
+import '../../../../../core/providers/shift_providers.dart';
+import '../../../../../core/providers/teacher_providers.dart';
+import '../../../../../core/providers/tenant_providers.dart';
+import '../../../../../core/theme/app_colors.dart';
+import '../../../../../data/models/parent/parent_model.dart';
+import '../../../../../data/models/person/person.dart';
+import '../../../../../data/models/shift/shift_plan.dart';
+import '../../../../../data/models/tenant/tenant.dart';
+import '../../../../../shared/widgets/editable/editable_info_row.dart';
+import '../../../../../shared/widgets/sheets/field_editor_sheet.dart';
+import '../../../../../shared/widgets/sheets/selection_sheet.dart';
+
+/// Callback type for person field changes.
+typedef PersonFieldChanged = void Function(String field, dynamic value);
+
+/// Accordion widget displaying general person information with inline editing.
+class AllgemeinAccordion extends ConsumerWidget {
+  const AllgemeinAccordion({
+    super.key,
+    required this.person,
+    required this.isExpanded,
+    required this.onToggle,
+    required this.onFieldChanged,
+    required this.canEdit,
+    this.selectedGroupId,
+    this.selectedTeacherId,
+    this.selectedShiftId,
+    this.selectedShiftName,
+    this.shiftStart,
+    this.selectedParentId,
+    this.isLeader,
+    this.hasTeacher,
+    this.additionalFieldValues,
+  });
+
+  final Person person;
+  final bool isExpanded;
+  final VoidCallback onToggle;
+  final PersonFieldChanged onFieldChanged;
+  final bool canEdit;
+
+  // Editable state values (passed from parent to allow draft state)
+  final int? selectedGroupId;
+  final int? selectedTeacherId;
+  final String? selectedShiftId;
+  final String? selectedShiftName;
+  final DateTime? shiftStart;
+  final int? selectedParentId;
+  final bool? isLeader;
+  final bool? hasTeacher;
+  final Map<String, dynamic>? additionalFieldValues;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final tenant = ref.watch(currentTenantProvider);
+    final extraFields = tenant?.additionalFields ?? [];
+    final additionalFields = additionalFieldValues ?? person.additionalFields ?? {};
+
+    return Card(
+      margin: const EdgeInsets.symmetric(
+        horizontal: AppDimensions.paddingM,
+        vertical: AppDimensions.paddingXS,
+      ),
+      child: Column(
+        children: [
+          ListTile(
+            title: const Text(
+              'Allgemein',
+              style: TextStyle(fontWeight: FontWeight.w600),
+            ),
+            trailing: Icon(isExpanded ? Icons.expand_less : Icons.expand_more),
+            onTap: onToggle,
+          ),
+          if (isExpanded)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(
+                AppDimensions.paddingM,
+                0,
+                AppDimensions.paddingM,
+                AppDimensions.paddingM,
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // Name fields
+                  _buildNameFields(context),
+                  const Divider(height: 24),
+
+                  // Notes
+                  _buildNotesField(context),
+
+                  // Group
+                  _buildGroupField(context, ref),
+
+                  // Phone
+                  _buildPhoneField(context),
+
+                  // Birthday
+                  if (person.birthday != null || canEdit)
+                    _buildDateField(
+                      context,
+                      icon: Icons.cake,
+                      label: 'Geburtsdatum',
+                      value: person.birthday,
+                      fieldKey: 'birthday',
+                      highlight: !person.correctBirthday,
+                      highlightColor: AppColors.warning,
+                    ),
+
+                  // Plays Since
+                  if (person.playsSince != null || canEdit)
+                    _buildDateField(
+                      context,
+                      icon: Icons.music_note,
+                      label: 'Spielt auf dem Instrument seit',
+                      value: person.playsSince,
+                      fieldKey: 'playsSince',
+                    ),
+
+                  // Joined
+                  if (person.joined != null || canEdit)
+                    _buildDateField(
+                      context,
+                      icon: Icons.login,
+                      label: 'Beigetreten am',
+                      value: person.joined,
+                      fieldKey: 'joined',
+                    ),
+
+                  // Is Leader toggle
+                  _buildIsLeaderField(context),
+
+                  // Has Teacher toggle
+                  _buildHasTeacherField(context, ref),
+
+                  // Shift Plan
+                  _buildShiftPlanField(context, ref),
+
+                  // Parent
+                  _buildParentField(context, ref),
+
+                  // Other Exercise
+                  if (person.otherExercise != null || canEdit)
+                    _buildOtherExerciseField(context),
+
+                  // Extra Fields
+                  if (extraFields.isNotEmpty) ...[
+                    const Divider(height: 32),
+                    Text(
+                      'Zusatzfelder',
+                      style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                            fontWeight: FontWeight.w600,
+                            color: AppColors.primary,
+                          ),
+                    ),
+                    const SizedBox(height: AppDimensions.paddingS),
+                    ...extraFields.map(
+                      (field) => _buildExtraField(context, field, additionalFields),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildNameFields(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: EditableInfoRow(
+            icon: Icons.person,
+            label: 'Vorname',
+            value: person.firstName,
+            editable: canEdit,
+            onEdit: () => _editTextField(
+              context,
+              title: 'Vorname',
+              initialValue: person.firstName,
+              fieldKey: 'firstName',
+              validator: (v) => v?.isEmpty ?? true ? 'Pflichtfeld' : null,
+            ),
+          ),
+        ),
+        Expanded(
+          child: EditableInfoRow(
+            icon: Icons.person_outline,
+            label: 'Nachname',
+            value: person.lastName,
+            editable: canEdit,
+            onEdit: () => _editTextField(
+              context,
+              title: 'Nachname',
+              initialValue: person.lastName,
+              fieldKey: 'lastName',
+              validator: (v) => v?.isEmpty ?? true ? 'Pflichtfeld' : null,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildNotesField(BuildContext context) {
+    final notes = person.notes;
+    if (notes == null && !canEdit) return const SizedBox.shrink();
+
+    return EditableInfoRow(
+      icon: Icons.notes,
+      label: 'Notizen',
+      value: notes ?? 'Keine Notizen',
+      editable: canEdit,
+      onEdit: () => _editTextField(
+        context,
+        title: 'Notizen',
+        initialValue: notes ?? '',
+        fieldKey: 'notes',
+        maxLines: 4,
+        hint: 'Notizen zur Person...',
+      ),
+    );
+  }
+
+  Widget _buildGroupField(BuildContext context, WidgetRef ref) {
+    final groupsAsync = ref.watch(groupsMapProvider);
+    final currentGroupId = selectedGroupId ?? person.instrument;
+
+    return groupsAsync.when(
+      loading: () => const LinearProgressIndicator(),
+      error: (e, _) => Text('Fehler: $e'),
+      data: (groups) {
+        final groupName = currentGroupId != null
+            ? groups[currentGroupId] ?? 'Unbekannt'
+            : 'Nicht zugewiesen';
+
+        return EditableInfoRow(
+          icon: Icons.group,
+          label: 'Gruppe',
+          value: groupName,
+          editable: canEdit,
+          onEdit: () async {
+            final items = groups.entries
+                .map((e) => SelectionItem(value: e.key, label: e.value))
+                .toList();
+
+            final result = await SelectionSheet.show<int>(
+              context,
+              title: 'Gruppe auswählen',
+              items: items,
+              selectedValue: currentGroupId,
+              noneLabel: 'Keine Gruppe',
+              icon: Icons.group,
+            );
+
+            if (result != null) {
+              onFieldChanged(
+                'instrument',
+                result.isNone ? null : result.value,
+              );
+            }
+          },
+        );
+      },
+    );
+  }
+
+  Widget _buildPhoneField(BuildContext context) {
+    final phone = person.phone;
+    if (phone == null && !canEdit) return const SizedBox.shrink();
+
+    return EditableInfoRow(
+      icon: Icons.phone,
+      label: 'Telefon',
+      value: phone ?? 'Nicht angegeben',
+      editable: canEdit,
+      onTap: phone != null ? () => _launchPhone(phone) : null,
+      onEdit: () => _editTextField(
+        context,
+        title: 'Telefon',
+        initialValue: phone ?? '',
+        fieldKey: 'phone',
+        keyboardType: TextInputType.phone,
+        icon: Icons.phone,
+      ),
+    );
+  }
+
+  Widget _buildDateField(
+    BuildContext context, {
+    required IconData icon,
+    required String label,
+    required String? value,
+    required String fieldKey,
+    bool highlight = false,
+    Color? highlightColor,
+  }) {
+    final displayValue = value != null ? _formatDate(value) : 'Nicht angegeben';
+
+    return EditableInfoRow(
+      icon: icon,
+      label: label,
+      value: displayValue,
+      editable: canEdit,
+      highlight: highlight,
+      highlightColor: highlightColor,
+      onEdit: () async {
+        final initialDate = value != null ? DateTime.tryParse(value) : null;
+        final date = await DateEditorSheet.show(
+          context,
+          title: label,
+          initialDate: initialDate,
+          lastDate: DateTime.now(),
+        );
+        if (date != null) {
+          onFieldChanged(fieldKey, date.toIso8601String());
+        }
+      },
+    );
+  }
+
+  Widget _buildIsLeaderField(BuildContext context) {
+    final value = isLeader ?? person.isLeader;
+
+    return EditableToggleRow(
+      icon: Icons.star,
+      label: 'Stimmführer',
+      value: value,
+      editable: canEdit,
+      onChanged: (v) => onFieldChanged('isLeader', v),
+    );
+  }
+
+  Widget _buildHasTeacherField(BuildContext context, WidgetRef ref) {
+    final hasTeacherValue = hasTeacher ?? person.hasTeacher;
+    final teacherId = selectedTeacherId ?? person.teacher;
+
+    return Column(
+      children: [
+        EditableToggleRow(
+          icon: Icons.school,
+          label: 'Spielt beim Lehrer',
+          value: hasTeacherValue,
+          editable: canEdit,
+          onChanged: (v) {
+            onFieldChanged('hasTeacher', v);
+            if (!v) {
+              onFieldChanged('teacher', null);
+            }
+          },
+        ),
+        if (hasTeacherValue)
+          _buildTeacherField(context, ref, teacherId),
+      ],
+    );
+  }
+
+  Widget _buildTeacherField(BuildContext context, WidgetRef ref, int? teacherId) {
+    final teachersAsync = ref.watch(teachersProvider);
+
+    return teachersAsync.when(
+      loading: () => const Padding(
+        padding: EdgeInsets.all(AppDimensions.paddingM),
+        child: LinearProgressIndicator(),
+      ),
+      error: (e, _) => Text('Fehler: $e'),
+      data: (teachers) {
+        final teacher = teachers.where((t) => t.id == teacherId).firstOrNull;
+        final teacherName = teacher?.fullName ?? 'Nicht ausgewählt';
+
+        return Padding(
+          padding: const EdgeInsets.only(left: AppDimensions.paddingL),
+          child: EditableInfoRow(
+            icon: Icons.person,
+            label: 'Lehrer',
+            value: teacherName,
+            editable: canEdit,
+            onEdit: () async {
+              final items = teachers
+                  .map((t) => SelectionItem(value: t.id!, label: t.fullName))
+                  .toList();
+
+              final result = await SelectionSheet.show<int>(
+                context,
+                title: 'Lehrer auswählen',
+                items: items,
+                selectedValue: teacherId,
+                noneLabel: 'Kein Lehrer',
+                icon: Icons.school,
+              );
+
+              if (result != null) {
+                onFieldChanged(
+                  'teacher',
+                  result.isNone ? null : result.value,
+                );
+              }
+            },
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildShiftPlanField(BuildContext context, WidgetRef ref) {
+    final shiftsAsync = ref.watch(shiftsProvider);
+    final currentShiftId = selectedShiftId ?? person.shiftId;
+
+    return shiftsAsync.when(
+      loading: () => const LinearProgressIndicator(),
+      error: (e, _) => Text('Fehler: $e'),
+      data: (shifts) {
+        final shift = shifts.where((s) => s.id == currentShiftId).firstOrNull;
+        final shiftName = shift?.name ?? 'Kein Schichtplan';
+
+        return Column(
+          children: [
+            EditableInfoRow(
+              icon: Icons.schedule,
+              label: 'Schichtplan',
+              value: shiftName,
+              editable: canEdit,
+              onEdit: () async {
+                final items = shifts
+                    .map((s) => SelectionItem(value: s.id!, label: s.name))
+                    .toList();
+
+                final result = await SelectionSheet.show<String>(
+                  context,
+                  title: 'Schichtplan auswählen',
+                  items: items,
+                  selectedValue: currentShiftId,
+                  noneLabel: 'Kein Schichtplan',
+                  icon: Icons.schedule,
+                );
+
+                if (result != null) {
+                  onFieldChanged(
+                    'shiftId',
+                    result.isNone ? null : result.value,
+                  );
+                  // Reset shift name and start when shift changes
+                  onFieldChanged('shiftName', null);
+                  onFieldChanged('shiftStart', null);
+                }
+              },
+            ),
+            // Show sub-shift selection if shift has named shifts
+            if (shift != null && shift.hasNamedShifts)
+              _buildShiftNameField(context, shift),
+            if (shift != null && !shift.hasNamedShifts)
+              _buildShiftStartField(context),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildShiftNameField(BuildContext context, dynamic shift) {
+    final currentShiftName = selectedShiftName ?? person.shiftName;
+    final uniqueShiftNames = shift.shifts
+        .map((s) => s.name as String)
+        .toSet()
+        .toList();
+
+    return Padding(
+      padding: const EdgeInsets.only(left: AppDimensions.paddingL),
+      child: EditableInfoRow(
+        icon: Icons.access_time,
+        label: 'Schicht',
+        value: currentShiftName ?? 'Nicht ausgewählt',
+        editable: canEdit,
+        onEdit: () async {
+          final items = uniqueShiftNames
+              .map((name) => SelectionItem(value: name, label: name))
+              .toList();
+
+          final result = await SelectionSheet.show<String>(
+            context,
+            title: 'Schicht auswählen',
+            items: items,
+            selectedValue: currentShiftName,
+            noneLabel: 'Keine Schicht',
+            icon: Icons.access_time,
+          );
+
+          if (result != null) {
+            onFieldChanged(
+              'shiftName',
+              result.isNone ? null : result.value,
+            );
+          }
+        },
+      ),
+    );
+  }
+
+  Widget _buildShiftStartField(BuildContext context) {
+    final currentShiftStart = shiftStart ??
+        (person.shiftStart != null ? DateTime.tryParse(person.shiftStart!) : null);
+
+    final displayValue = currentShiftStart != null
+        ? DateFormat('dd.MM.yyyy').format(currentShiftStart)
+        : 'Nicht angegeben';
+
+    return Padding(
+      padding: const EdgeInsets.only(left: AppDimensions.paddingL),
+      child: EditableInfoRow(
+        icon: Icons.calendar_today,
+        label: 'Schichtplan-Start',
+        value: displayValue,
+        editable: canEdit,
+        onEdit: () async {
+          final date = await DateEditorSheet.show(
+            context,
+            title: 'Schichtplan-Start',
+            initialDate: currentShiftStart,
+            firstDate: DateTime(2000),
+            lastDate: DateTime(2100),
+          );
+          if (date != null) {
+            onFieldChanged('shiftStart', date.toIso8601String());
+          }
+        },
+      ),
+    );
+  }
+
+  Widget _buildParentField(BuildContext context, WidgetRef ref) {
+    final parentsAsync = ref.watch(parentsProvider);
+    final currentParentId = selectedParentId ?? person.parentId;
+
+    return parentsAsync.when(
+      loading: () => const LinearProgressIndicator(),
+      error: (e, _) => Text('Fehler: $e'),
+      data: (parents) {
+        final parent = parents.where((p) => p.id == currentParentId).firstOrNull;
+        final parentName = parent?.fullName ?? 'Nicht zugewiesen';
+
+        return EditableInfoRow(
+          icon: Icons.family_restroom,
+          label: 'Erziehungsberechtigter',
+          value: parentName,
+          editable: canEdit,
+          onEdit: () async {
+            final items = parents
+                .map((p) => SelectionItem(value: p.id!, label: p.fullName))
+                .toList();
+
+            final result = await SelectionSheet.show<int>(
+              context,
+              title: 'Erziehungsberechtigten auswählen',
+              items: items,
+              selectedValue: currentParentId,
+              noneLabel: 'Kein Erziehungsberechtigter',
+              icon: Icons.family_restroom,
+            );
+
+            if (result != null) {
+              onFieldChanged(
+                'parentId',
+                result.isNone ? null : result.value,
+              );
+            }
+          },
+        );
+      },
+    );
+  }
+
+  Widget _buildOtherExerciseField(BuildContext context) {
+    final otherExercise = person.otherExercise;
+
+    return EditableInfoRow(
+      icon: Icons.work,
+      label: 'Sonstige Dienste',
+      value: otherExercise ?? 'Nicht angegeben',
+      editable: canEdit,
+      onEdit: () => _editTextField(
+        context,
+        title: 'Sonstige Dienste',
+        initialValue: otherExercise ?? '',
+        fieldKey: 'otherExercise',
+        hint: 'Weitere Aufgaben...',
+      ),
+    );
+  }
+
+  Widget _buildExtraField(
+    BuildContext context,
+    ExtraField field,
+    Map<String, dynamic> additionalFields,
+  ) {
+    final value = additionalFields[field.id];
+    final displayValue = _formatExtraFieldValue(field, value);
+    final icon = _getExtraFieldIcon(field.type);
+
+    if (field.type == 'boolean') {
+      return EditableToggleRow(
+        icon: icon,
+        label: field.name,
+        value: value == true,
+        editable: canEdit,
+        onChanged: (v) => onFieldChanged('additionalFields.${field.id}', v),
+      );
+    }
+
+    return EditableInfoRow(
+      icon: icon,
+      label: field.name,
+      value: displayValue,
+      editable: canEdit,
+      onEdit: () => _editExtraField(context, field, value),
+    );
+  }
+
+  void _editExtraField(BuildContext context, ExtraField field, dynamic currentValue) async {
+    switch (field.type) {
+      case 'text':
+      case 'textarea':
+        final result = await FieldEditorSheet.show(
+          context,
+          title: field.name,
+          initialValue: currentValue?.toString() ?? '',
+          maxLines: field.type == 'textarea' ? 4 : 1,
+        );
+        if (result != null) {
+          onFieldChanged('additionalFields.${field.id}', result);
+        }
+        break;
+
+      case 'number':
+        final result = await FieldEditorSheet.show(
+          context,
+          title: field.name,
+          initialValue: currentValue?.toString() ?? '',
+          keyboardType: TextInputType.number,
+        );
+        if (result != null) {
+          onFieldChanged('additionalFields.${field.id}', int.tryParse(result) ?? 0);
+        }
+        break;
+
+      case 'date':
+        final initialDate = currentValue != null
+            ? DateTime.tryParse(currentValue.toString())
+            : null;
+        final date = await DateEditorSheet.show(
+          context,
+          title: field.name,
+          initialDate: initialDate,
+        );
+        if (date != null) {
+          onFieldChanged(
+            'additionalFields.${field.id}',
+            date.toIso8601String().split('T')[0],
+          );
+        }
+        break;
+
+      case 'select':
+        final options = field.options ?? [];
+        final items = options
+            .map((opt) => SelectionItem(value: opt, label: opt))
+            .toList();
+        final result = await SelectionSheet.show<String>(
+          context,
+          title: field.name,
+          items: items,
+          selectedValue: currentValue?.toString(),
+        );
+        if (result != null) {
+          onFieldChanged(
+            'additionalFields.${field.id}',
+            result.isNone ? null : result.value,
+          );
+        }
+        break;
+    }
+  }
+
+  Future<void> _editTextField(
+    BuildContext context, {
+    required String title,
+    required String initialValue,
+    required String fieldKey,
+    int maxLines = 1,
+    String? hint,
+    TextInputType? keyboardType,
+    String? Function(String?)? validator,
+    IconData? icon,
+  }) async {
+    final result = await FieldEditorSheet.show(
+      context,
+      title: title,
+      initialValue: initialValue,
+      hint: hint,
+      maxLines: maxLines,
+      keyboardType: keyboardType,
+      validator: validator,
+      icon: icon,
+    );
+    if (result != null) {
+      onFieldChanged(fieldKey, result.isEmpty ? null : result);
+    }
+  }
+
+  void _launchPhone(String phone) {
+    // TODO: Implement phone launch
+  }
+
+  String _formatDate(String dateStr) {
+    final date = DateTime.tryParse(dateStr);
+    if (date == null) return dateStr;
+    return DateFormat('dd.MM.yyyy').format(date);
+  }
+
+  String _formatExtraFieldValue(ExtraField field, dynamic value) {
+    if (value == null) return 'Nicht angegeben';
+
+    switch (field.type) {
+      case 'boolean':
+        return value == true ? 'Ja' : 'Nein';
+      case 'date':
+        final date = DateTime.tryParse(value.toString());
+        if (date != null) {
+          return DateFormat('dd.MM.yyyy').format(date);
+        }
+        return value.toString();
+      default:
+        return value.toString();
+    }
+  }
+
+  IconData _getExtraFieldIcon(String type) {
+    switch (type) {
+      case 'text':
+        return Icons.text_fields;
+      case 'textarea':
+        return Icons.notes;
+      case 'number':
+        return Icons.numbers;
+      case 'date':
+        return Icons.calendar_today;
+      case 'boolean':
+        return Icons.toggle_on;
+      case 'select':
+        return Icons.list;
+      default:
+        return Icons.text_fields;
+    }
+  }
+}

--- a/lib/features/people/presentation/widgets/person_detail/historie_accordion.dart
+++ b/lib/features/people/presentation/widgets/person_detail/historie_accordion.dart
@@ -1,0 +1,255 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+
+import '../../../../../core/constants/app_constants.dart';
+import '../../../../../core/constants/enums.dart';
+import '../../../../../core/theme/app_colors.dart';
+
+/// Accordion section displaying person history (attendance + changes).
+class HistorieAccordion extends ConsumerWidget {
+  const HistorieAccordion({
+    super.key,
+    required this.isExpanded,
+    required this.onToggle,
+    required this.historyAsync,
+    required this.statsAsync,
+  });
+
+  final bool isExpanded;
+  final VoidCallback onToggle;
+  final AsyncValue<List<Map<String, dynamic>>> historyAsync;
+  final AsyncValue<Map<String, dynamic>> statsAsync;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Card(
+      margin: const EdgeInsets.symmetric(
+        horizontal: AppDimensions.paddingM,
+        vertical: AppDimensions.paddingXS,
+      ),
+      child: Column(
+        children: [
+          ListTile(
+            title: const Text(
+              'Historie',
+              style: TextStyle(fontWeight: FontWeight.w600),
+            ),
+            trailing: Icon(isExpanded ? Icons.expand_less : Icons.expand_more),
+            onTap: onToggle,
+          ),
+          if (isExpanded)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(
+                AppDimensions.paddingM,
+                0,
+                AppDimensions.paddingM,
+                AppDimensions.paddingM,
+              ),
+              child: _buildContent(context),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildContent(BuildContext context) {
+    return historyAsync.when(
+      loading: () => const Center(
+        child: Padding(
+          padding: EdgeInsets.all(AppDimensions.paddingL),
+          child: CircularProgressIndicator(),
+        ),
+      ),
+      error: (error, _) => Center(child: Text('Fehler: $error')),
+      data: (history) {
+        if (history.isEmpty) {
+          return const Padding(
+            padding: EdgeInsets.all(AppDimensions.paddingL),
+            child: Center(
+              child: Column(
+                children: [
+                  Icon(Icons.history, size: 48, color: AppColors.medium),
+                  SizedBox(height: AppDimensions.paddingS),
+                  Text('Keine Historie vorhanden'),
+                ],
+              ),
+            ),
+          );
+        }
+
+        return Column(
+          children: [
+            // Stats summary row
+            _buildStatsRow(),
+
+            // History items
+            ...history.take(20).map((item) => _buildHistoryItem(item)),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildStatsRow() {
+    return statsAsync.when(
+      loading: () => const SizedBox.shrink(),
+      error: (_, __) => const SizedBox.shrink(),
+      data: (stats) {
+        final percentage = stats['percentage'] as int;
+        final lateCount = stats['lateCount'] as int;
+        final lateText = lateCount > 0 ? ' (${lateCount}x zu spät)' : '';
+        final badgeColor = percentage >= 75
+            ? AppColors.success
+            : percentage >= 50
+                ? AppColors.warning
+                : AppColors.danger;
+
+        return Container(
+          padding: const EdgeInsets.symmetric(vertical: AppDimensions.paddingM),
+          decoration: BoxDecoration(
+            border: Border(bottom: BorderSide(color: Colors.grey.shade200)),
+          ),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  'Durchschnitt$lateText',
+                  style: const TextStyle(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                decoration: BoxDecoration(
+                  color: badgeColor,
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                child: Text(
+                  '$percentage%',
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
+                    fontSize: 14,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildHistoryItem(Map<String, dynamic> item) {
+    final date = DateTime.tryParse(item['date'] ?? '');
+    final type = item['type'] as int?;
+    final text = item['text']?.toString() ?? '';
+    final meetingName = item['meetingName']?.toString();
+    final notes = item['notes']?.toString();
+
+    // Determine display title
+    String displayTitle = '';
+    if (type == PlayerHistoryType.attendance.value) {
+      displayTitle = meetingName ?? '';
+    } else {
+      switch (type) {
+        case 0: // paused
+          displayTitle = 'Pausiert';
+          break;
+        case 5: // active
+          displayTitle = 'Wieder aktiv';
+          break;
+        case 6: // instrumentChange
+          displayTitle = 'Gruppenwechsel';
+          break;
+        case 7: // archived
+          displayTitle = 'Archiviert';
+          break;
+        default:
+          displayTitle = item['title']?.toString() ?? 'Eintrag';
+      }
+    }
+
+    // Build badge for attendance status
+    String? badgeText;
+    Color? badgeColor;
+    if (type == PlayerHistoryType.attendance.value) {
+      if (text == 'X') {
+        badgeText = '✓';
+        badgeColor = AppColors.success;
+      } else if (text == 'L') {
+        badgeText = 'L';
+        badgeColor = AppColors.tertiary;
+      } else if (text == 'E') {
+        badgeText = 'E';
+        badgeColor = AppColors.warning;
+      } else if (text == 'N') {
+        badgeText = 'N';
+        badgeColor = AppColors.medium;
+      } else {
+        badgeText = 'A';
+        badgeColor = AppColors.danger;
+      }
+    }
+
+    final dateStr = date != null ? DateFormat('dd.MM.yyyy').format(date) : '';
+    final titleStr = displayTitle.isNotEmpty ? '$dateStr | $displayTitle' : dateStr;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: AppDimensions.paddingM),
+      decoration: BoxDecoration(
+        border: Border(bottom: BorderSide(color: Colors.grey.shade100)),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(titleStr, style: const TextStyle(fontSize: 15)),
+                if (notes != null && notes.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 2),
+                    child: Text(
+                      notes,
+                      style: TextStyle(fontSize: 12, color: Colors.grey.shade600),
+                    ),
+                  ),
+                if (type != PlayerHistoryType.attendance.value && text.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 2),
+                    child: Text(
+                      text,
+                      style: TextStyle(fontSize: 12, color: Colors.grey.shade600),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          if (badgeText != null)
+            Container(
+              width: 32,
+              height: 32,
+              decoration: BoxDecoration(
+                color: badgeColor,
+                borderRadius: BorderRadius.circular(4),
+              ),
+              child: Center(
+                child: Text(
+                  badgeText,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
+                    fontSize: 16,
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/people/presentation/widgets/person_detail/late_warning_card.dart
+++ b/lib/features/people/presentation/widgets/person_detail/late_warning_card.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../../core/constants/app_constants.dart';
+import '../../../../../core/providers/tenant_providers.dart';
+import '../../../../../data/models/person/person.dart';
+
+/// Card showing late warning with threshold information and reset button.
+class LateWarningCard extends ConsumerWidget {
+  const LateWarningCard({
+    super.key,
+    required this.person,
+    required this.statsAsync,
+    required this.onResetLateCount,
+  });
+
+  final Person person;
+  final AsyncValue<Map<String, dynamic>> statsAsync;
+  final VoidCallback onResetLateCount;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return statsAsync.when(
+      loading: () => const SizedBox.shrink(),
+      error: (_, __) => const SizedBox.shrink(),
+      data: (stats) {
+        final lateCount = stats['lateCount'] as int? ?? 0;
+
+        // Get threshold from tenant's critical rules
+        final tenant = ref.watch(currentTenantProvider);
+        int threshold = 3;
+        if (tenant?.criticalRules != null) {
+          for (final rule in tenant!.criticalRules!) {
+            // Status 3 = late
+            if (rule.statuses.contains(3)) {
+              threshold = rule.thresholdValue;
+              break;
+            }
+          }
+        }
+
+        if (lateCount < threshold) return const SizedBox.shrink();
+
+        return Card(
+          margin: const EdgeInsets.all(AppDimensions.paddingM),
+          color: Colors.orange.shade50,
+          child: ListTile(
+            leading: Container(
+              padding: const EdgeInsets.all(8),
+              decoration: BoxDecoration(
+                color: Colors.orange.shade100,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: const Icon(Icons.schedule, color: Colors.orange),
+            ),
+            title: const Text(
+              'Häufige Verspätungen',
+              style: TextStyle(fontWeight: FontWeight.w600),
+            ),
+            subtitle: Text(
+              '$lateCount× unentschuldigt zu spät (Schwelle: $threshold)',
+              style: TextStyle(color: Colors.orange.shade800),
+            ),
+            trailing: FilledButton.tonal(
+              onPressed: onResetLateCount,
+              child: const Text('Zurücksetzen'),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/people/presentation/widgets/person_detail/person_detail.dart
+++ b/lib/features/people/presentation/widgets/person_detail/person_detail.dart
@@ -1,0 +1,7 @@
+export 'account_accordion.dart';
+export 'allgemein_accordion.dart';
+export 'historie_accordion.dart';
+export 'late_warning_card.dart';
+export 'person_header.dart';
+export 'person_status_badges.dart';
+export 'problemfall_accordion.dart';

--- a/lib/features/people/presentation/widgets/person_detail/person_header.dart
+++ b/lib/features/people/presentation/widgets/person_detail/person_header.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../../core/constants/app_constants.dart';
+import '../../../../../core/theme/app_colors.dart';
+import '../../../../../data/models/person/person.dart';
+
+/// Header widget displaying person avatar, group, and attendance stats.
+class PersonHeader extends StatelessWidget {
+  const PersonHeader({
+    super.key,
+    required this.person,
+    required this.statsAsync,
+  });
+
+  final Person person;
+  final AsyncValue<Map<String, dynamic>> statsAsync;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(AppDimensions.paddingL),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: [
+            person.isCritical ? AppColors.danger : AppColors.primary,
+            (person.isCritical ? AppColors.danger : AppColors.primary)
+                .withValues(alpha: 0.7),
+          ],
+        ),
+      ),
+      child: Column(
+        children: [
+          Hero(
+            tag: 'person-${person.id}',
+            child: CircleAvatar(
+              radius: 50,
+              backgroundColor: Colors.white,
+              backgroundImage:
+                  person.img != null && !person.img!.contains('.svg')
+                      ? NetworkImage(person.img!)
+                      : null,
+              child: person.img == null || person.img!.contains('.svg')
+                  ? Text(
+                      person.initials,
+                      style: const TextStyle(
+                        fontSize: 36,
+                        fontWeight: FontWeight.bold,
+                        color: AppColors.primary,
+                      ),
+                    )
+                  : null,
+            ),
+          ),
+          const SizedBox(height: AppDimensions.paddingM),
+          if (person.groupName != null)
+            Container(
+              padding: const EdgeInsets.symmetric(
+                horizontal: AppDimensions.paddingM,
+                vertical: AppDimensions.paddingXS,
+              ),
+              decoration: BoxDecoration(
+                color: Colors.white.withValues(alpha: 0.2),
+                borderRadius: BorderRadius.circular(AppDimensions.borderRadiusS),
+              ),
+              child: Text(
+                person.groupName!,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ),
+          const SizedBox(height: AppDimensions.paddingM),
+          statsAsync.when(
+            loading: () => const SizedBox.shrink(),
+            error: (_, __) => const SizedBox.shrink(),
+            data: (stats) => Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                _StatItem(
+                  value: '${stats['percentage']}%',
+                  label: stats['lateCount'] > 0
+                      ? 'Anwesenheit (${stats['lateCount']}x zu spät)'
+                      : 'Anwesenheit',
+                  color: stats['percentage'] >= 75
+                      ? AppColors.success
+                      : stats['percentage'] >= 50
+                          ? AppColors.warning
+                          : AppColors.danger,
+                ),
+                Container(
+                  width: 1,
+                  height: 40,
+                  margin: const EdgeInsets.symmetric(
+                    horizontal: AppDimensions.paddingL,
+                  ),
+                  color: Colors.white.withValues(alpha: 0.3),
+                ),
+                _StatItem(
+                  value: '${stats['attended']}/${stats['total']}',
+                  label: 'Termine',
+                  color: Colors.white,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StatItem extends StatelessWidget {
+  const _StatItem({
+    required this.value,
+    required this.label,
+    required this.color,
+  });
+
+  final String value;
+  final String label;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Text(
+          value,
+          style: TextStyle(
+            color: color,
+            fontSize: 24,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          label,
+          style: TextStyle(
+            color: Colors.white.withValues(alpha: 0.8),
+            fontSize: 12,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/people/presentation/widgets/person_detail/person_status_badges.dart
+++ b/lib/features/people/presentation/widgets/person_detail/person_status_badges.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../../../../../core/constants/app_constants.dart';
+import '../../../../../core/theme/app_colors.dart';
+import '../../../../../data/models/person/person.dart';
+
+/// Widget displaying status badges for a person (archived, paused, critical, etc.).
+class PersonStatusBadges extends StatelessWidget {
+  const PersonStatusBadges({super.key, required this.person});
+
+  final Person person;
+
+  @override
+  Widget build(BuildContext context) {
+    final badges = _buildBadges();
+    if (badges.isEmpty) return const SizedBox.shrink();
+
+    return Padding(
+      padding: const EdgeInsets.all(AppDimensions.paddingM),
+      child: Wrap(
+        spacing: AppDimensions.paddingS,
+        runSpacing: AppDimensions.paddingS,
+        children: badges,
+      ),
+    );
+  }
+
+  bool get hasStatusBadges =>
+      person.archived ||
+      person.paused ||
+      person.isCritical ||
+      person.pending ||
+      person.isLeader;
+
+  List<Widget> _buildBadges() {
+    final badges = <Widget>[];
+    if (person.archived) {
+      badges.add(const _StatusBadge(
+        label: 'Archiviert',
+        color: AppColors.medium,
+        icon: Icons.archive,
+      ));
+    }
+    if (person.paused) {
+      final label = person.pausedUntil != null
+          ? 'Pausiert bis ${_formatDate(person.pausedUntil!)}'
+          : 'Pausiert';
+      badges.add(_StatusBadge(
+        label: label,
+        color: AppColors.warning,
+        icon: Icons.pause_circle,
+      ));
+    }
+    if (person.isCritical) {
+      badges.add(const _StatusBadge(
+        label: 'Kritisch',
+        color: AppColors.danger,
+        icon: Icons.warning,
+      ));
+    }
+    if (person.pending) {
+      badges.add(const _StatusBadge(
+        label: 'Ausstehend',
+        color: AppColors.info,
+        icon: Icons.hourglass_empty,
+      ));
+    }
+    if (person.isLeader) {
+      badges.add(const _StatusBadge(
+        label: 'Stimmführer',
+        color: AppColors.success,
+        icon: Icons.star,
+      ));
+    }
+    return badges;
+  }
+
+  String _formatDate(String dateStr) {
+    final date = DateTime.tryParse(dateStr);
+    if (date == null) return dateStr;
+    return DateFormat('dd.MM.yyyy').format(date);
+  }
+}
+
+class _StatusBadge extends StatelessWidget {
+  const _StatusBadge({
+    required this.label,
+    required this.color,
+    required this.icon,
+  });
+
+  final String label;
+  final Color color;
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppDimensions.paddingS,
+        vertical: AppDimensions.paddingXS,
+      ),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(AppDimensions.borderRadiusS),
+        border: Border.all(color: color.withValues(alpha: 0.3)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 16, color: color),
+          const SizedBox(width: 4),
+          Text(
+            label,
+            style: TextStyle(
+              color: color,
+              fontSize: 12,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/people/presentation/widgets/person_detail/problemfall_accordion.dart
+++ b/lib/features/people/presentation/widgets/person_detail/problemfall_accordion.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+
+import '../../../../../core/constants/app_constants.dart';
+import '../../../../../core/theme/app_colors.dart';
+import '../../../../../data/models/person/person.dart';
+
+/// Accordion section for problem person management.
+class ProblemfallAccordion extends StatelessWidget {
+  const ProblemfallAccordion({
+    super.key,
+    required this.person,
+    required this.isExpanded,
+    required this.onToggle,
+    required this.problemSolved,
+    required this.onProblemSolvedChanged,
+    required this.problemNotes,
+    required this.onProblemNotesChanged,
+    required this.onResolveProblem,
+  });
+
+  final Person person;
+  final bool isExpanded;
+  final VoidCallback onToggle;
+  final bool problemSolved;
+  final ValueChanged<bool> onProblemSolvedChanged;
+  final String problemNotes;
+  final ValueChanged<String> onProblemNotesChanged;
+  final VoidCallback onResolveProblem;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!person.isCritical) return const SizedBox.shrink();
+
+    return Card(
+      margin: const EdgeInsets.symmetric(
+        horizontal: AppDimensions.paddingM,
+        vertical: AppDimensions.paddingXS,
+      ),
+      child: Column(
+        children: [
+          ListTile(
+            title: const Text(
+              'Problemfall',
+              style: TextStyle(fontWeight: FontWeight.w600),
+            ),
+            trailing: Icon(isExpanded ? Icons.expand_less : Icons.expand_more),
+            onTap: onToggle,
+          ),
+          if (isExpanded)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(
+                AppDimensions.paddingM,
+                0,
+                AppDimensions.paddingM,
+                AppDimensions.paddingM,
+              ),
+              child: _buildContent(context),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildContent(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Reason display
+        if (person.criticalReason != null && person.criticalReason!.isNotEmpty) ...[
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(AppDimensions.paddingM),
+            decoration: BoxDecoration(
+              color: AppColors.danger.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(AppDimensions.borderRadiusS),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  'Grund',
+                  style: TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                    color: AppColors.danger,
+                  ),
+                ),
+                const SizedBox(height: AppDimensions.paddingXS),
+                Text(
+                  person.criticalReason!,
+                  style: const TextStyle(color: AppColors.dark),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: AppDimensions.paddingM),
+        ],
+
+        // Problem solved toggle
+        SwitchListTile(
+          contentPadding: EdgeInsets.zero,
+          title: const Text('Mit Person gesprochen'),
+          subtitle: const Text('Bestätigen, dass das Problem besprochen wurde'),
+          value: problemSolved,
+          onChanged: onProblemSolvedChanged,
+          activeColor: AppColors.success,
+        ),
+
+        // Notes and resolve button (only when solved)
+        if (problemSolved) ...[
+          const SizedBox(height: AppDimensions.paddingM),
+          TextField(
+            decoration: const InputDecoration(
+              labelText: 'Anmerkungen (optional)',
+              hintText: 'Was wurde besprochen?',
+              border: OutlineInputBorder(),
+            ),
+            maxLines: 3,
+            onChanged: onProblemNotesChanged,
+          ),
+          const SizedBox(height: AppDimensions.paddingM),
+          SizedBox(
+            width: double.infinity,
+            child: FilledButton.icon(
+              onPressed: onResolveProblem,
+              icon: const Icon(Icons.check_circle),
+              label: const Text('Problem als gelöst markieren'),
+              style: FilledButton.styleFrom(
+                backgroundColor: AppColors.success,
+              ),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}

--- a/lib/shared/widgets/editable/editable.dart
+++ b/lib/shared/widgets/editable/editable.dart
@@ -1,0 +1,1 @@
+export 'editable_info_row.dart';

--- a/lib/shared/widgets/editable/editable_info_row.dart
+++ b/lib/shared/widgets/editable/editable_info_row.dart
@@ -1,0 +1,220 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/constants/app_constants.dart';
+import '../../../core/theme/app_colors.dart';
+
+/// An info row that can be tapped to edit the value.
+/// Used for inline-editing in detail pages.
+class EditableInfoRow extends StatelessWidget {
+  const EditableInfoRow({
+    super.key,
+    required this.icon,
+    required this.label,
+    required this.value,
+    this.onTap,
+    this.onEdit,
+    this.editable = false,
+    this.highlight = false,
+    this.highlightColor,
+    this.subtitle,
+  });
+
+  final IconData icon;
+  final String label;
+  final String value;
+  final VoidCallback? onTap;
+  final VoidCallback? onEdit;
+  final bool editable;
+  final bool highlight;
+  final Color? highlightColor;
+  final String? subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    final effectiveHighlightColor = highlightColor ?? AppColors.warning;
+
+    return InkWell(
+      onTap: editable ? onEdit : onTap,
+      borderRadius: BorderRadius.circular(AppDimensions.borderRadiusS),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          vertical: AppDimensions.paddingS,
+          horizontal: AppDimensions.paddingXS,
+        ),
+        child: Row(
+          children: [
+            Container(
+              padding: const EdgeInsets.all(8),
+              decoration: BoxDecoration(
+                color: highlight
+                    ? effectiveHighlightColor.withValues(alpha: 0.1)
+                    : AppColors.primary.withValues(alpha: 0.1),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Icon(
+                icon,
+                size: 20,
+                color: highlight ? effectiveHighlightColor : AppColors.primary,
+              ),
+            ),
+            const SizedBox(width: AppDimensions.paddingM),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    label,
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: highlight ? effectiveHighlightColor : AppColors.medium,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    value,
+                    style: TextStyle(
+                      fontSize: 15,
+                      color: highlight ? effectiveHighlightColor : null,
+                      fontWeight: highlight ? FontWeight.w500 : null,
+                    ),
+                  ),
+                  if (subtitle != null) ...[
+                    const SizedBox(height: 2),
+                    Text(
+                      subtitle!,
+                      style: const TextStyle(
+                        fontSize: 12,
+                        color: AppColors.medium,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+            if (onTap != null && !editable)
+              const Icon(Icons.chevron_right, color: AppColors.medium),
+            if (editable)
+              Icon(
+                Icons.edit,
+                size: 18,
+                color: AppColors.primary.withValues(alpha: 0.6),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// A read-only info row (non-editable version).
+/// For display-only fields or when editing is not permitted.
+class InfoRow extends StatelessWidget {
+  const InfoRow({
+    super.key,
+    required this.icon,
+    required this.label,
+    required this.value,
+    this.onTap,
+    this.highlight = false,
+    this.highlightColor,
+    this.subtitle,
+  });
+
+  final IconData icon;
+  final String label;
+  final String value;
+  final VoidCallback? onTap;
+  final bool highlight;
+  final Color? highlightColor;
+  final String? subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    return EditableInfoRow(
+      icon: icon,
+      label: label,
+      value: value,
+      onTap: onTap,
+      highlight: highlight,
+      highlightColor: highlightColor,
+      subtitle: subtitle,
+      editable: false,
+    );
+  }
+}
+
+/// A toggle row for boolean values with inline switch.
+class EditableToggleRow extends StatelessWidget {
+  const EditableToggleRow({
+    super.key,
+    required this.icon,
+    required this.label,
+    required this.value,
+    this.onChanged,
+    this.editable = false,
+    this.subtitle,
+  });
+
+  final IconData icon;
+  final String label;
+  final bool value;
+  final ValueChanged<bool>? onChanged;
+  final bool editable;
+  final String? subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        vertical: AppDimensions.paddingXS,
+        horizontal: AppDimensions.paddingXS,
+      ),
+      child: Row(
+        children: [
+          Container(
+            padding: const EdgeInsets.all(8),
+            decoration: BoxDecoration(
+              color: AppColors.primary.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Icon(
+              icon,
+              size: 20,
+              color: AppColors.primary,
+            ),
+          ),
+          const SizedBox(width: AppDimensions.paddingM),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  label,
+                  style: const TextStyle(
+                    fontSize: 12,
+                    color: AppColors.medium,
+                  ),
+                ),
+                if (subtitle != null) ...[
+                  const SizedBox(height: 2),
+                  Text(
+                    subtitle!,
+                    style: const TextStyle(
+                      fontSize: 12,
+                      color: AppColors.medium,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+          Switch(
+            value: value,
+            onChanged: editable ? onChanged : null,
+            activeColor: AppColors.success,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/shared/widgets/sheets/field_editor_sheet.dart
+++ b/lib/shared/widgets/sheets/field_editor_sheet.dart
@@ -1,0 +1,200 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/constants/app_constants.dart';
+import '../../../core/theme/app_colors.dart';
+
+/// A reusable BottomSheet for editing text/multiline fields.
+/// Shows a text field with title, optional hint, and save/cancel buttons.
+class FieldEditorSheet extends StatefulWidget {
+  const FieldEditorSheet({
+    super.key,
+    required this.title,
+    this.initialValue,
+    this.hint,
+    this.maxLines = 1,
+    this.keyboardType,
+    this.validator,
+    this.icon,
+    this.iconColor,
+    this.confirmText = 'Speichern',
+    this.cancelText = 'Abbrechen',
+  });
+
+  final String title;
+  final String? initialValue;
+  final String? hint;
+  final int maxLines;
+  final TextInputType? keyboardType;
+  final String? Function(String?)? validator;
+  final IconData? icon;
+  final Color? iconColor;
+  final String confirmText;
+  final String cancelText;
+
+  /// Shows the field editor sheet and returns the new value, or null if cancelled.
+  static Future<String?> show(
+    BuildContext context, {
+    required String title,
+    String? initialValue,
+    String? hint,
+    int maxLines = 1,
+    TextInputType? keyboardType,
+    String? Function(String?)? validator,
+    IconData? icon,
+    Color? iconColor,
+    String confirmText = 'Speichern',
+    String cancelText = 'Abbrechen',
+  }) async {
+    return showModalBottomSheet<String>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      builder: (context) => FieldEditorSheet(
+        title: title,
+        initialValue: initialValue,
+        hint: hint,
+        maxLines: maxLines,
+        keyboardType: keyboardType,
+        validator: validator,
+        icon: icon,
+        iconColor: iconColor,
+        confirmText: confirmText,
+        cancelText: cancelText,
+      ),
+    );
+  }
+
+  @override
+  State<FieldEditorSheet> createState() => _FieldEditorSheetState();
+}
+
+class _FieldEditorSheetState extends State<FieldEditorSheet> {
+  late TextEditingController _controller;
+  final _formKey = GlobalKey<FormState>();
+  String? _errorText;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initialValue);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    if (widget.validator != null) {
+      final error = widget.validator!(_controller.text);
+      if (error != null) {
+        setState(() => _errorText = error);
+        return;
+      }
+    }
+    Navigator.pop(context, _controller.text);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.of(context).viewInsets.bottom,
+        left: AppDimensions.paddingL,
+        right: AppDimensions.paddingL,
+        top: AppDimensions.paddingL,
+      ),
+      child: Form(
+        key: _formKey,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            // Header row with title and close button
+            Row(
+              children: [
+                if (widget.icon != null) ...[
+                  Icon(
+                    widget.icon,
+                    color: widget.iconColor ?? AppColors.primary,
+                    size: 28,
+                  ),
+                  const SizedBox(width: AppDimensions.paddingS),
+                ],
+                Expanded(
+                  child: Text(
+                    widget.title,
+                    style: Theme.of(context).textTheme.titleLarge,
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.close),
+                  onPressed: () => Navigator.pop(context),
+                ),
+              ],
+            ),
+            const SizedBox(height: AppDimensions.paddingL),
+
+            // Text field
+            TextField(
+              controller: _controller,
+              decoration: InputDecoration(
+                hintText: widget.hint,
+                border: const OutlineInputBorder(),
+                errorText: _errorText,
+              ),
+              maxLines: widget.maxLines,
+              keyboardType: widget.keyboardType,
+              autofocus: true,
+              onChanged: (_) {
+                if (_errorText != null) {
+                  setState(() => _errorText = null);
+                }
+              },
+              onSubmitted: widget.maxLines == 1 ? (_) => _submit() : null,
+            ),
+            const SizedBox(height: AppDimensions.paddingL),
+
+            // Action buttons
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                TextButton(
+                  onPressed: () => Navigator.pop(context),
+                  child: Text(widget.cancelText),
+                ),
+                const SizedBox(width: AppDimensions.paddingS),
+                FilledButton(
+                  onPressed: _submit,
+                  child: Text(widget.confirmText),
+                ),
+              ],
+            ),
+            const SizedBox(height: AppDimensions.paddingL),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// A date picker sheet that shows a calendar and returns the selected date.
+class DateEditorSheet {
+  /// Shows a date picker and returns the selected date, or null if cancelled.
+  static Future<DateTime?> show(
+    BuildContext context, {
+    required String title,
+    DateTime? initialDate,
+    DateTime? firstDate,
+    DateTime? lastDate,
+  }) async {
+    final now = DateTime.now();
+    return showDatePicker(
+      context: context,
+      initialDate: initialDate ?? now,
+      firstDate: firstDate ?? DateTime(1900),
+      lastDate: lastDate ?? DateTime(2100),
+    );
+  }
+}

--- a/lib/shared/widgets/sheets/selection_sheet.dart
+++ b/lib/shared/widgets/sheets/selection_sheet.dart
@@ -1,0 +1,272 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/constants/app_constants.dart';
+import '../../../core/theme/app_colors.dart';
+
+/// A selection item for the SelectionSheet.
+class SelectionItem<T> {
+  const SelectionItem({
+    required this.value,
+    required this.label,
+    this.subtitle,
+    this.icon,
+  });
+
+  final T value;
+  final String label;
+  final String? subtitle;
+  final IconData? icon;
+}
+
+/// A reusable BottomSheet for selecting from a list of options.
+/// Supports search filtering and a "none" option.
+class SelectionSheet<T> extends StatefulWidget {
+  const SelectionSheet({
+    super.key,
+    required this.title,
+    required this.items,
+    this.selectedValue,
+    this.searchHint = 'Suchen...',
+    this.noneLabel,
+    this.showSearch = true,
+    this.icon,
+    this.iconColor,
+  });
+
+  final String title;
+  final List<SelectionItem<T>> items;
+  final T? selectedValue;
+  final String searchHint;
+  final String? noneLabel;
+  final bool showSearch;
+  final IconData? icon;
+  final Color? iconColor;
+
+  /// Shows the selection sheet and returns the selected value.
+  /// Returns the selected value, or null if the "none" option was selected.
+  /// Returns the same value (unchanged) if the sheet was dismissed.
+  static Future<SelectionResult<T>?> show<T>(
+    BuildContext context, {
+    required String title,
+    required List<SelectionItem<T>> items,
+    T? selectedValue,
+    String searchHint = 'Suchen...',
+    String? noneLabel,
+    bool showSearch = true,
+    IconData? icon,
+    Color? iconColor,
+  }) async {
+    return showModalBottomSheet<SelectionResult<T>>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      builder: (context) => SelectionSheet<T>(
+        title: title,
+        items: items,
+        selectedValue: selectedValue,
+        searchHint: searchHint,
+        noneLabel: noneLabel,
+        showSearch: showSearch,
+        icon: icon,
+        iconColor: iconColor,
+      ),
+    );
+  }
+
+  @override
+  State<SelectionSheet<T>> createState() => _SelectionSheetState<T>();
+}
+
+/// Result of the selection sheet.
+class SelectionResult<T> {
+  const SelectionResult({this.value, this.isNone = false});
+
+  final T? value;
+  final bool isNone;
+
+  /// Creates a result with the selected value.
+  factory SelectionResult.selected(T value) => SelectionResult(value: value);
+
+  /// Creates a result with no selection (none option).
+  factory SelectionResult.none() => const SelectionResult(isNone: true);
+}
+
+class _SelectionSheetState<T> extends State<SelectionSheet<T>> {
+  late TextEditingController _searchController;
+  String _searchQuery = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _searchController = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  List<SelectionItem<T>> get _filteredItems {
+    if (_searchQuery.isEmpty) return widget.items;
+    final query = _searchQuery.toLowerCase();
+    return widget.items.where((item) {
+      return item.label.toLowerCase().contains(query) ||
+          (item.subtitle?.toLowerCase().contains(query) ?? false);
+    }).toList();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final maxHeight = MediaQuery.of(context).size.height * 0.7;
+
+    return ConstrainedBox(
+      constraints: BoxConstraints(maxHeight: maxHeight),
+      child: Padding(
+        padding: const EdgeInsets.only(
+          left: AppDimensions.paddingL,
+          right: AppDimensions.paddingL,
+          top: AppDimensions.paddingL,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            // Header row with title and close button
+            Row(
+              children: [
+                if (widget.icon != null) ...[
+                  Icon(
+                    widget.icon,
+                    color: widget.iconColor ?? AppColors.primary,
+                    size: 28,
+                  ),
+                  const SizedBox(width: AppDimensions.paddingS),
+                ],
+                Expanded(
+                  child: Text(
+                    widget.title,
+                    style: Theme.of(context).textTheme.titleLarge,
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.close),
+                  onPressed: () => Navigator.pop(context),
+                ),
+              ],
+            ),
+
+            // Search field
+            if (widget.showSearch && widget.items.length > 5) ...[
+              const SizedBox(height: AppDimensions.paddingM),
+              TextField(
+                controller: _searchController,
+                decoration: InputDecoration(
+                  hintText: widget.searchHint,
+                  prefixIcon: const Icon(Icons.search),
+                  border: const OutlineInputBorder(),
+                  suffixIcon: _searchQuery.isNotEmpty
+                      ? IconButton(
+                          icon: const Icon(Icons.clear),
+                          onPressed: () {
+                            _searchController.clear();
+                            setState(() => _searchQuery = '');
+                          },
+                        )
+                      : null,
+                ),
+                onChanged: (value) => setState(() => _searchQuery = value),
+              ),
+            ],
+            const SizedBox(height: AppDimensions.paddingM),
+
+            // Options list
+            Flexible(
+              child: ListView(
+                shrinkWrap: true,
+                children: [
+                  // None option
+                  if (widget.noneLabel != null)
+                    _SelectionTile<T>(
+                      label: widget.noneLabel!,
+                      isSelected: widget.selectedValue == null,
+                      onTap: () => Navigator.pop(
+                        context,
+                        SelectionResult<T>.none(),
+                      ),
+                    ),
+
+                  // Items
+                  ..._filteredItems.map((item) => _SelectionTile<T>(
+                        label: item.label,
+                        subtitle: item.subtitle,
+                        icon: item.icon,
+                        isSelected: item.value == widget.selectedValue,
+                        onTap: () => Navigator.pop(
+                          context,
+                          SelectionResult<T>.selected(item.value),
+                        ),
+                      )),
+
+                  // Empty state
+                  if (_filteredItems.isEmpty && _searchQuery.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.all(AppDimensions.paddingL),
+                      child: Center(
+                        child: Text(
+                          'Keine Ergebnisse für "$_searchQuery"',
+                          style: const TextStyle(color: AppColors.medium),
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+            const SizedBox(height: AppDimensions.paddingM),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SelectionTile<T> extends StatelessWidget {
+  const _SelectionTile({
+    required this.label,
+    this.subtitle,
+    this.icon,
+    this.isSelected = false,
+    required this.onTap,
+  });
+
+  final String label;
+  final String? subtitle;
+  final IconData? icon;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: icon != null
+          ? Icon(icon, color: isSelected ? AppColors.primary : AppColors.medium)
+          : null,
+      title: Text(
+        label,
+        style: TextStyle(
+          fontWeight: isSelected ? FontWeight.w600 : null,
+          color: isSelected ? AppColors.primary : null,
+        ),
+      ),
+      subtitle: subtitle != null ? Text(subtitle!) : null,
+      trailing: isSelected
+          ? const Icon(Icons.check, color: AppColors.primary)
+          : null,
+      onTap: onTap,
+      selected: isSelected,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(AppDimensions.borderRadiusS),
+      ),
+    );
+  }
+}

--- a/lib/shared/widgets/sheets/sheets.dart
+++ b/lib/shared/widgets/sheets/sheets.dart
@@ -1,0 +1,5 @@
+export 'feedback_sheet.dart';
+export 'field_editor_sheet.dart';
+export 'image_viewer_sheet.dart';
+export 'selection_sheet.dart';
+export 'version_history_sheet.dart';

--- a/lib/shared/widgets/widgets.dart
+++ b/lib/shared/widgets/widgets.dart
@@ -2,5 +2,7 @@
 export 'animations/animations.dart';
 export 'common/common.dart';
 export 'display/display.dart';
+export 'editable/editable.dart';
 export 'loading/loading.dart';
 export 'layout/main_shell.dart';
+export 'sheets/sheets.dart';


### PR DESCRIPTION
## Summary

- Refactored PersonDetailPage from View/Edit toggle pattern to tap-to-dialog inline editing
- Reduced main file from ~2400 to ~850 lines by extracting 7 accordion components
- Added 3 new reusable shared widgets for inline editing (EditableInfoRow, FieldEditorSheet, SelectionSheet)
- Improved UX: edit fields directly in accordions with 1-2 taps instead of 4+

## Changes

### New Shared Widgets
- `EditableInfoRow` / `EditableToggleRow` - Tappable info rows with edit indicator
- `FieldEditorSheet` - BottomSheet for text/multiline field editing
- `SelectionSheet` - BottomSheet for dropdown selection with search

### Extracted Components (`lib/features/people/presentation/widgets/person_detail/`)
- `PersonHeader` - Avatar, group badge, and attendance stats
- `PersonStatusBadges` - Archived, paused, critical, etc. badges
- `LateWarningCard` - Late count warning with reset button
- `AllgemeinAccordion` - General info with full inline editing
- `AccountAccordion` - Email, role selector, account management
- `HistorieAccordion` - Attendance and change history
- `ProblemfallAccordion` - Problem person resolution

## Test Plan

- [x] `dart analyze lib/` - No errors
- [x] `flutter test` - All 343 tests pass
- [ ] Manual test: Navigate to person detail, edit fields inline
- [ ] Manual test: Verify FAB appears only when changes exist
- [ ] Manual test: Verify save persists all changed fields