### PR TITLE
fix(planning): Invalidate attendance providers after saving plan

### DIFF
--- a/lib/features/planning/presentation/pages/planning_page.dart
+++ b/lib/features/planning/presentation/pages/planning_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/config/supabase_config.dart';
 import '../../../../core/constants/app_constants.dart';
+import '../../../../core/providers/attendance_detail_providers.dart';
 import '../../../../core/providers/attendance_type_providers.dart';
 import '../../../../core/providers/song_providers.dart';
 import '../../../../core/services/export_service.dart';
@@ -849,6 +850,10 @@ class _PlanningPageState extends ConsumerState<PlanningPage> {
           })
           .eq('id', _selectedAttendanceId!)
           .eq('tenantId', tenant!.id!);
+
+      // Invalidate providers so other pages see the updated plan
+      ref.invalidate(attendanceDetailProvider(_selectedAttendanceId!));
+      ref.invalidate(upcomingAttendancesProvider);
     } catch (e) {
       // Silent fail - auto-save
     }


### PR DESCRIPTION
## Summary

Fix stale data issue when navigating back from planning page to attendance detail.

- Invalidate `attendanceDetailProvider` after saving plan
- Invalidate `upcomingAttendancesProvider` after saving plan

This ensures other pages immediately see the updated plan data without requiring a manual refresh.

## Test Plan
- [ ] Go to attendance detail → Ablaufplan erstellen
- [ ] Add a field and go back
- [ ] Verify the plan is shown correctly on attendance detail
- [ ] Go to Ablaufplan bearbeiten and verify data is current