### PR TITLE
fix(planning): Load existing plan when opening with attendanceId

### DIFF
--- a/lib/features/planning/presentation/pages/planning_page.dart
+++ b/lib/features/planning/presentation/pages/planning_page.dart
@@ -108,6 +108,7 @@ class _PlanningPageState extends ConsumerState<PlanningPage> {
     FieldSelection(id: 'default', name: 'Wort', time: '10'),
   ];
   bool _hasChanges = false;
+  bool _initialLoadDone = false;
 
   @override
   void initState() {
@@ -193,13 +194,25 @@ class _PlanningPageState extends ConsumerState<PlanningPage> {
                 );
               }
 
-              // Auto-select first if none selected
-              if (_selectedAttendanceId == null && attendances.isNotEmpty) {
+              // Load plan on first build
+              if (!_initialLoadDone) {
                 WidgetsBinding.instance.addPostFrameCallback((_) {
-                  setState(() {
-                    _selectedAttendanceId = attendances.first.id;
+                  if (!mounted) return;
+                  _initialLoadDone = true;
+
+                  // If attendanceId was passed, find and load that attendance
+                  if (_selectedAttendanceId != null) {
+                    final att = attendances.where((a) => a.id == _selectedAttendanceId).firstOrNull;
+                    if (att != null) {
+                      _loadPlanFromAttendance(att);
+                    }
+                  } else if (attendances.isNotEmpty) {
+                    // Auto-select first if none selected
+                    setState(() {
+                      _selectedAttendanceId = attendances.first.id;
+                    });
                     _loadPlanFromAttendance(attendances.first);
-                  });
+                  }
                 });
               }
 


### PR DESCRIPTION
## Summary

Fix: When clicking "Bearbeiten" on an attendance with an existing plan, the default plan was shown instead of the actual saved plan.

**Root cause:** The code only loaded the plan when `_selectedAttendanceId == null`, but when navigating with an `attendanceId` parameter, `_selectedAttendanceId` was already set in `initState`.

**Fix:** Use `_initialLoadDone` flag to ensure plan is loaded exactly once on first build, regardless of whether `attendanceId` was passed or auto-selected.

## Test Plan
- [ ] Create an attendance with a plan (multiple fields)
- [ ] Navigate away, then click "Ablaufplan bearbeiten"
- [ ] Verify the existing plan fields are shown, not the default "Wort" field