### PR TITLE
fix: Add null-checks for tenant.id before force unwrap

### DIFF
--- a/lib/features/people/presentation/pages/people_list_page.dart
+++ b/lib/features/people/presentation/pages/people_list_page.dart
@@ -26,7 +26,7 @@ final peopleListProvider = FutureProvider<List<Person>>((ref) async {
   final groups = await ref.watch(groupsMapProvider.future);
   final repository = ref.watch(playerRepositoryWithTenantProvider);
 
-  if (tenant == null) return [];
+  if (tenant == null || tenant.id == null) return [];
 
   // Check for auto-unpause (players whose pause period has ended)
   await repository.checkAndUnpausePlayers();

--- a/lib/features/people/presentation/pages/person_detail_page.dart
+++ b/lib/features/people/presentation/pages/person_detail_page.dart
@@ -22,7 +22,7 @@ final personProvider =
   final tenant = ref.watch(currentTenantProvider);
   final groups = await ref.watch(groupsMapProvider.future);
 
-  if (tenant == null) return null;
+  if (tenant == null || tenant.id == null) return null;
 
   final response = await supabase
       .from('player')
@@ -62,7 +62,8 @@ final personAttendanceStatsProvider =
   int? latePeriodDays;
 
   if (tenant?.criticalRules != null) {
-    for (final rule in tenant!.criticalRules!) {
+    final rules = tenant!.criticalRules!;
+    for (final rule in rules) {
       if (rule.statuses.contains(3) && rule.enabled) {
         lateStatuses = rule.statuses;
         latePeriodType = rule.periodType;

--- a/lib/features/people/presentation/widgets/person_detail/late_warning_card.dart
+++ b/lib/features/people/presentation/widgets/person_detail/late_warning_card.dart
@@ -31,7 +31,8 @@ class LateWarningCard extends ConsumerWidget {
         final tenant = ref.watch(currentTenantProvider);
         int threshold = 3;
         if (tenant?.criticalRules != null) {
-          for (final rule in tenant!.criticalRules!) {
+          final rules = tenant!.criticalRules!;
+          for (final rule in rules) {
             // Status 3 = late
             if (rule.statuses.contains(3)) {
               threshold = rule.thresholdValue;


### PR DESCRIPTION
## Summary
- Adds null-checks for `tenant.id` before force unwrap to prevent crashes
- Extracts `criticalRules` to local variables for better code clarity

## Changes
- `people_list_page.dart`: Check `tenant.id != null` before `.eq()` query
- `person_detail_page.dart`: Check `tenant.id != null` in personProvider
- `person_detail_page.dart`: Extract criticalRules to local variable
- `late_warning_card.dart`: Extract criticalRules to local variable

## Test plan
- [x] All 348 tests pass
- [x] dart analyze shows no issues

Closes #162