### PR TITLE
fix(attendance): ensure status changes persist reliably

### DIFF
--- a/assets/version_history.json
+++ b/assets/version_history.json
@@ -1,6 +1,13 @@
 {
   "versions": [
     {
+      "version": "0.1.15",
+      "date": "4.3.2026",
+      "changes": [
+        "🐛 Anwesenheit: Status-Änderungen werden jetzt zuverlässig gespeichert"
+      ]
+    },
+    {
       "version": "0.1.14",
       "date": "4.3.2026",
       "changes": [

--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -8,7 +8,7 @@ class AppConstants {
   AppConstants._();
 
   static const String appName = 'Attendix';
-  static const String appVersion = '0.1.14';
+  static const String appVersion = '0.1.15';
 
   /// Demo credentials from environment (for development only)
   /// SEC-009: Only expose in debug mode

--- a/lib/features/attendance/presentation/pages/attendance_detail_page.dart
+++ b/lib/features/attendance/presentation/pages/attendance_detail_page.dart
@@ -158,20 +158,21 @@ class _AttendanceDetailPageState extends ConsumerState<AttendanceDetailPage> {
 
         final value = next.value;
         if (value != null) {
-          final isFirstLoad = _localStatuses.isEmpty;
-          if (isFirstLoad) {
-            setState(() {
-              for (final pa in value) {
-                if (pa.personId != null) {
+          setState(() {
+            for (final pa in value) {
+              if (pa.personId != null) {
+                // IDs und Metadaten IMMER aktualisieren
+                _personAttendanceIds[pa.personId!] = pa.id;
+                _personNotes[pa.personId!] = pa.notes;
+                _changedBy[pa.personId!] = pa.changedBy;
+                _changedAt[pa.personId!] = pa.changedAt;
+                // Status nur setzen wenn nicht gerade lokal geändert
+                if (!_savingPersonIds.contains(pa.personId!)) {
                   _localStatuses[pa.personId!] = pa.status;
-                  _personAttendanceIds[pa.personId!] = pa.id;
-                  _personNotes[pa.personId!] = pa.notes;
-                  _changedBy[pa.personId!] = pa.changedBy;
-                  _changedAt[pa.personId!] = pa.changedAt;
                 }
               }
-            });
-          }
+            }
+          });
         }
       },
       fireImmediately: true,
@@ -274,9 +275,11 @@ class _AttendanceDetailPageState extends ConsumerState<AttendanceDetailPage> {
 
       if (_isDisposed || !mounted) return;
 
+      final recordId = newRecord['id']?.toString();
       try {
         setState(() {
           _localStatuses[personId] = status;
+          if (recordId != null) _personAttendanceIds[personId] = recordId;
           _personNotes[personId] = notes;
           _changedBy[personId] = changedBy;
           _changedAt[personId] = changedAt;
@@ -1588,7 +1591,14 @@ class _AttendanceDetailPageState extends ConsumerState<AttendanceDetailPage> {
     AttendanceStatus? previousStatus,
   }) async {
     final personAttendanceId = _personAttendanceIds[personId];
-    if (personAttendanceId == null) return;
+    if (personAttendanceId == null) {
+      if (mounted && previousStatus != null) {
+        setState(() {
+          _localStatuses[personId] = previousStatus;
+        });
+      }
+      return;
+    }
 
     _savingPersonIds.add(personId);
     try {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: attendix
 description: "Attendance Management App - Flutter Version"
 publish_to: 'none'
-version: 0.1.14+15
+version: 0.1.15+16
 
 environment:
   sdk: ^3.7.0


### PR DESCRIPTION
## Summary
- **Provider listener**: Always updates `_personAttendanceIds` and metadata on every callback, not just on first load. Only `_localStatuses` is protected from overwrite during active saves.
- **Realtime callback**: Now also writes the record `id` into `_personAttendanceIds` so saves work even when the ID came from a realtime event.
- **Save fallback**: Reverts optimistic UI update when `personAttendanceId` is null instead of silently aborting.

## Root Cause
`_personAttendanceIds` was only populated inside an `isFirstLoad` gate (`_localStatuses.isEmpty`). If a realtime event populated `_localStatuses` before the provider fired, `isFirstLoad` was false and IDs were never set — causing `_savePersonStatus` to silently return without persisting.

## Test plan
- [ ] Open attendance detail, change a status, navigate away, come back — status persists
- [ ] Open attendance on two devices, change status on one — realtime update appears on the other
- [ ] `dart analyze lib/` — no new warnings
- [ ] `flutter test` — all 234+ tests pass