### PR TITLE
fix(meetings): DB column name, notes clearing, HTML handling, and role check

### DIFF
--- a/assets/version_history.json
+++ b/assets/version_history.json
@@ -1,6 +1,16 @@
 {
   "versions": [
     {
+      "version": "0.1.19",
+      "date": "4.3.2026",
+      "changes": [
+        "🐛 Besprechungen: Teilnehmer & Notizen speichern repariert (DB-Spaltenname)",
+        "🐛 Besprechungen: Notizen löschen jetzt möglich",
+        "🐛 Besprechungen: Vorschau zeigt lesbaren Text statt JSON",
+        "🔒 Besprechungen: Löschen-Button nur für berechtigte Rollen"
+      ]
+    },
+    {
       "version": "0.1.18",
       "date": "4.3.2026",
       "changes": [

--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -8,7 +8,7 @@ class AppConstants {
   AppConstants._();
 
   static const String appName = 'Attendix';
-  static const String appVersion = '0.1.18';
+  static const String appVersion = '0.1.19';
 
   /// Demo credentials from environment (for development only)
   /// SEC-009: Only expose in debug mode

--- a/lib/core/utils/quill_utils.dart
+++ b/lib/core/utils/quill_utils.dart
@@ -4,12 +4,37 @@ import 'package:flutter_quill/flutter_quill.dart';
 
 /// Utility class for converting between Quill Delta JSON and Document objects.
 ///
-/// Handles three input formats:
+/// Handles four input formats:
 /// - Quill Delta JSON array: `[{"insert":"Hello\n"}]`
 /// - Quill Delta JSON object: `{"ops":[{"insert":"Hello\n"}]}`
+/// - HTML (legacy Ionic data): `<p>Hello</p>`
 /// - Plain text fallback for legacy data
 class QuillUtils {
   QuillUtils._();
+
+  static final _htmlTagRegExp = RegExp(r'<[^>]+>');
+
+  /// Strips HTML tags and decodes common entities to plain text.
+  static String stripHtml(String html) {
+    return html
+        .replaceAll(RegExp(r'<br\s*/?>|</p>|</li>|</h[1-6]>'), '\n')
+        .replaceAll(_htmlTagRegExp, '')
+        .replaceAll('&nbsp;', ' ')
+        .replaceAll('&amp;', '&')
+        .replaceAll('&lt;', '<')
+        .replaceAll('&gt;', '>')
+        .replaceAll('&quot;', '"')
+        .replaceAll('&#39;', "'")
+        .replaceAll('&mdash;', '—')
+        .replaceAll('&ndash;', '–')
+        .replaceAll(RegExp(r'\n{3,}'), '\n\n')
+        .trim();
+  }
+
+  /// Returns true if the string looks like HTML content.
+  static bool _isHtml(String text) {
+    return text.trimLeft().startsWith('<') && _htmlTagRegExp.hasMatch(text);
+  }
 
   /// Creates a [Document] from a notes string stored in the database.
   ///
@@ -17,6 +42,7 @@ class QuillUtils {
   /// - `null` or empty → empty Document
   /// - JSON array `[{"insert":"..."}]` → Quill Delta
   /// - JSON object `{"ops":[...]}` → Quill Delta
+  /// - HTML → stripped to plain text, then inserted into Document
   /// - Plain text → Document with text content
   static Document documentFromNotesString(String? notes) {
     if (notes == null || notes.trim().isEmpty) {
@@ -38,7 +64,14 @@ class QuillUtils {
         }
       }
     } catch (_) {
-      // Not valid JSON — treat as plain text
+      // Not valid JSON — check for HTML or treat as plain text
+    }
+
+    // HTML fallback (legacy Ionic data)
+    if (_isHtml(notes)) {
+      final plainText = stripHtml(notes);
+      if (plainText.isEmpty) return Document();
+      return Document()..insert(0, plainText);
     }
 
     // Plain text fallback

--- a/lib/core/utils/quill_utils.dart
+++ b/lib/core/utils/quill_utils.dart
@@ -1,14 +1,18 @@
 import 'dart:convert';
 
 import 'package:flutter_quill/flutter_quill.dart';
+import 'package:flutter_quill_delta_from_html/flutter_quill_delta_from_html.dart';
+import 'package:vsc_quill_delta_to_html/vsc_quill_delta_to_html.dart';
 
-/// Utility class for converting between Quill Delta JSON and Document objects.
+/// Utility class for converting between Quill Delta, HTML, and Document objects.
 ///
-/// Handles four input formats:
+/// Handles four input formats for reading:
 /// - Quill Delta JSON array: `[{"insert":"Hello\n"}]`
 /// - Quill Delta JSON object: `{"ops":[{"insert":"Hello\n"}]}`
-/// - HTML (legacy Ionic data): `<p>Hello</p>`
+/// - HTML (Ionic app format): `<p>Hello</p>`
 /// - Plain text fallback for legacy data
+///
+/// Always writes as HTML for backward compatibility with the Ionic app.
 class QuillUtils {
   QuillUtils._();
 
@@ -42,7 +46,7 @@ class QuillUtils {
   /// - `null` or empty → empty Document
   /// - JSON array `[{"insert":"..."}]` → Quill Delta
   /// - JSON object `{"ops":[...]}` → Quill Delta
-  /// - HTML → stripped to plain text, then inserted into Document
+  /// - HTML → converted to Quill Delta (preserving formatting)
   /// - Plain text → Document with text content
   static Document documentFromNotesString(String? notes) {
     if (notes == null || notes.trim().isEmpty) {
@@ -67,21 +71,40 @@ class QuillUtils {
       // Not valid JSON — check for HTML or treat as plain text
     }
 
-    // HTML fallback (legacy Ionic data)
+    // HTML → Quill Delta (preserves formatting like bold, lists, headers)
     if (_isHtml(notes)) {
-      final plainText = stripHtml(notes);
-      if (plainText.isEmpty) return Document();
-      return Document()..insert(0, plainText);
+      try {
+        final delta = HtmlToDelta().convert(notes);
+        return Document.fromDelta(delta);
+      } catch (_) {
+        // Fallback: strip HTML to plain text
+        final plainText = stripHtml(notes);
+        if (plainText.isEmpty) return Document();
+        return Document()..insert(0, plainText);
+      }
     }
 
     // Plain text fallback
     return Document()..insert(0, notes);
   }
 
+  /// Serializes a [Document] to HTML for database storage.
+  ///
+  /// Returns HTML string compatible with the Ionic app,
+  /// or `null` if the document is empty.
+  static String? notesHtmlFromDocument(Document doc) {
+    if (isDocumentEmpty(doc)) return null;
+    final deltaJson = doc.toDelta().toJson();
+    final ops = deltaJson.cast<Map<String, dynamic>>();
+    final converter = QuillDeltaToHtmlConverter(ops);
+    return converter.convert();
+  }
+
   /// Serializes a [Document] back to a JSON string for database storage.
   ///
   /// Returns the ops array as a JSON string (compatible with quill.js),
   /// or `null` if the document is empty.
+  @Deprecated('Use notesHtmlFromDocument for backward compatibility with Ionic')
   static String? notesStringFromDocument(Document doc) {
     if (isDocumentEmpty(doc)) return null;
     return jsonEncode(doc.toDelta().toJson());

--- a/lib/data/models/meeting/meeting.dart
+++ b/lib/data/models/meeting/meeting.dart
@@ -2,6 +2,8 @@ import 'dart:convert';
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import '../../../core/utils/quill_utils.dart';
+
 part 'meeting.freezed.dart';
 part 'meeting.g.dart';
 
@@ -37,7 +39,8 @@ extension MeetingExtension on Meeting {
     return weekdays[d.weekday - 1];
   }
 
-  /// Extract plain text from Quill Delta JSON notes for list preview
+  /// Extract plain text from notes for list preview.
+  /// Handles Quill Delta JSON, HTML (legacy Ionic), and plain text.
   String? get plainTextPreview {
     if (notes == null || notes!.isEmpty) return null;
     try {
@@ -56,6 +59,12 @@ extension MeetingExtension on Meeting {
         return text.isEmpty ? null : text;
       }
     } catch (_) {}
-    return notes!.trim();
+    // HTML fallback (legacy Ionic data)
+    final trimmed = notes!.trim();
+    if (trimmed.startsWith('<')) {
+      final text = QuillUtils.stripHtml(trimmed);
+      return text.isEmpty ? null : text;
+    }
+    return trimmed;
   }
 }

--- a/lib/data/models/meeting/meeting.dart
+++ b/lib/data/models/meeting/meeting.dart
@@ -40,11 +40,13 @@ extension MeetingExtension on Meeting {
   }
 
   /// Extract plain text from notes for list preview.
-  /// Handles Quill Delta JSON, HTML (legacy Ionic), and plain text.
+  /// Handles HTML (Ionic + Flutter), Quill Delta JSON (legacy Flutter), and plain text.
   String? get plainTextPreview {
     if (notes == null || notes!.isEmpty) return null;
+    final trimmed = notes!.trim();
+    // Quill Delta JSON (legacy Flutter saves)
     try {
-      final decoded = jsonDecode(notes!.trim());
+      final decoded = jsonDecode(trimmed);
       List? ops;
       if (decoded is List) {
         ops = decoded;
@@ -59,12 +61,12 @@ extension MeetingExtension on Meeting {
         return text.isEmpty ? null : text;
       }
     } catch (_) {}
-    // HTML fallback (legacy Ionic data)
-    final trimmed = notes!.trim();
+    // HTML (Ionic app + new Flutter saves)
     if (trimmed.startsWith('<')) {
       final text = QuillUtils.stripHtml(trimmed);
       return text.isEmpty ? null : text;
     }
+    // Plain text fallback
     return trimmed;
   }
 }

--- a/lib/data/models/meeting/meeting.dart
+++ b/lib/data/models/meeting/meeting.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'meeting.freezed.dart';
@@ -12,7 +14,7 @@ class Meeting with _$Meeting {
     required int tenantId,
     required String date,
     String? notes,
-    @JsonKey(name: 'attendee_ids') List<int>? attendeeIds,
+    @JsonKey(name: 'attendees') List<int>? attendeeIds,
   }) = _Meeting;
 
   factory Meeting.fromJson(Map<String, dynamic> json) => _$MeetingFromJson(json);
@@ -33,5 +35,27 @@ extension MeetingExtension on Meeting {
     if (d == null) return '';
     const weekdays = ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'];
     return weekdays[d.weekday - 1];
+  }
+
+  /// Extract plain text from Quill Delta JSON notes for list preview
+  String? get plainTextPreview {
+    if (notes == null || notes!.isEmpty) return null;
+    try {
+      final decoded = jsonDecode(notes!.trim());
+      List? ops;
+      if (decoded is List) {
+        ops = decoded;
+      } else if (decoded is Map) {
+        ops = decoded['ops'] as List?;
+      }
+      if (ops != null) {
+        final text = ops
+            .map((op) => (op as Map)['insert']?.toString() ?? '')
+            .join('')
+            .trim();
+        return text.isEmpty ? null : text;
+      }
+    } catch (_) {}
+    return notes!.trim();
   }
 }

--- a/lib/data/models/meeting/meeting.freezed.dart
+++ b/lib/data/models/meeting/meeting.freezed.dart
@@ -27,7 +27,7 @@ mixin _$Meeting {
   int get tenantId => throw _privateConstructorUsedError;
   String get date => throw _privateConstructorUsedError;
   String? get notes => throw _privateConstructorUsedError;
-  @JsonKey(name: 'attendee_ids')
+  @JsonKey(name: 'attendees')
   List<int>? get attendeeIds => throw _privateConstructorUsedError;
 
   /// Serializes this Meeting to a JSON map.
@@ -50,7 +50,7 @@ abstract class $MeetingCopyWith<$Res> {
     int tenantId,
     String date,
     String? notes,
-    @JsonKey(name: 'attendee_ids') List<int>? attendeeIds,
+    @JsonKey(name: 'attendees') List<int>? attendeeIds,
   });
 }
 
@@ -128,7 +128,7 @@ abstract class _$$MeetingImplCopyWith<$Res> implements $MeetingCopyWith<$Res> {
     int tenantId,
     String date,
     String? notes,
-    @JsonKey(name: 'attendee_ids') List<int>? attendeeIds,
+    @JsonKey(name: 'attendees') List<int>? attendeeIds,
   });
 }
 
@@ -199,7 +199,7 @@ class _$MeetingImpl implements _Meeting {
     required this.tenantId,
     required this.date,
     this.notes,
-    @JsonKey(name: 'attendee_ids') final List<int>? attendeeIds,
+    @JsonKey(name: 'attendees') final List<int>? attendeeIds,
   }) : _attendeeIds = attendeeIds;
 
   factory _$MeetingImpl.fromJson(Map<String, dynamic> json) =>
@@ -218,7 +218,7 @@ class _$MeetingImpl implements _Meeting {
   final String? notes;
   final List<int>? _attendeeIds;
   @override
-  @JsonKey(name: 'attendee_ids')
+  @JsonKey(name: 'attendees')
   List<int>? get attendeeIds {
     final value = _attendeeIds;
     if (value == null) return null;
@@ -283,7 +283,7 @@ abstract class _Meeting implements Meeting {
     required final int tenantId,
     required final String date,
     final String? notes,
-    @JsonKey(name: 'attendee_ids') final List<int>? attendeeIds,
+    @JsonKey(name: 'attendees') final List<int>? attendeeIds,
   }) = _$MeetingImpl;
 
   factory _Meeting.fromJson(Map<String, dynamic> json) = _$MeetingImpl.fromJson;
@@ -300,7 +300,7 @@ abstract class _Meeting implements Meeting {
   @override
   String? get notes;
   @override
-  @JsonKey(name: 'attendee_ids')
+  @JsonKey(name: 'attendees')
   List<int>? get attendeeIds;
 
   /// Create a copy of Meeting

--- a/lib/data/models/meeting/meeting.g.dart
+++ b/lib/data/models/meeting/meeting.g.dart
@@ -17,7 +17,7 @@ _$MeetingImpl _$$MeetingImplFromJson(Map<String, dynamic> json) =>
       date: json['date'] as String,
       notes: json['notes'] as String?,
       attendeeIds:
-          (json['attendee_ids'] as List<dynamic>?)
+          (json['attendees'] as List<dynamic>?)
               ?.map((e) => (e as num).toInt())
               .toList(),
     );
@@ -29,5 +29,5 @@ Map<String, dynamic> _$$MeetingImplToJson(_$MeetingImpl instance) =>
       'tenantId': instance.tenantId,
       'date': instance.date,
       'notes': instance.notes,
-      'attendee_ids': instance.attendeeIds,
+      'attendees': instance.attendeeIds,
     };

--- a/lib/data/repositories/meeting_repository.dart
+++ b/lib/data/repositories/meeting_repository.dart
@@ -68,7 +68,7 @@ class MeetingRepository extends BaseRepository with TenantAwareRepository {
         'tenantId': currentTenantId,
         'date': meeting.date,
         'notes': meeting.notes,
-        'attendee_ids': meeting.attendeeIds,
+        'attendees': meeting.attendeeIds,
       };
 
       final response = await supabase
@@ -110,7 +110,7 @@ class MeetingRepository extends BaseRepository with TenantAwareRepository {
       final updates = <String, dynamic>{};
       if (date != null) updates['date'] = date;
       if (notes != null) updates['notes'] = notes;
-      if (attendeeIds != null) updates['attendee_ids'] = attendeeIds;
+      if (attendeeIds != null) updates['attendees'] = attendeeIds;
 
       final response = await supabase
           .from('meetings')

--- a/lib/features/meetings/presentation/pages/meeting_detail_page.dart
+++ b/lib/features/meetings/presentation/pages/meeting_detail_page.dart
@@ -65,7 +65,7 @@ class _MeetingDetailPageState extends ConsumerState<MeetingDetailPage> {
   Future<void> _save() async {
     final notifier = ref.read(meetingNotifierProvider.notifier);
     final notesJson = _quillController != null
-        ? QuillUtils.notesStringFromDocument(_quillController!.document)
+        ? (QuillUtils.notesStringFromDocument(_quillController!.document) ?? '')
         : null;
 
     final result = await notifier.updateMeeting(

--- a/lib/features/meetings/presentation/pages/meeting_detail_page.dart
+++ b/lib/features/meetings/presentation/pages/meeting_detail_page.dart
@@ -64,13 +64,13 @@ class _MeetingDetailPageState extends ConsumerState<MeetingDetailPage> {
 
   Future<void> _save() async {
     final notifier = ref.read(meetingNotifierProvider.notifier);
-    final notesJson = _quillController != null
-        ? (QuillUtils.notesStringFromDocument(_quillController!.document) ?? '')
+    final notesHtml = _quillController != null
+        ? (QuillUtils.notesHtmlFromDocument(_quillController!.document) ?? '')
         : null;
 
     final result = await notifier.updateMeeting(
       widget.meetingId,
-      notes: notesJson,
+      notes: notesHtml,
       attendeeIds: _selectedAttendeeIds,
     );
 

--- a/lib/features/meetings/presentation/pages/meetings_list_page.dart
+++ b/lib/features/meetings/presentation/pages/meetings_list_page.dart
@@ -89,7 +89,9 @@ class MeetingsListPage extends ConsumerWidget {
                 return _MeetingListItem(
                   meeting: meeting,
                   onTap: () => context.push('/settings/meetings/${meeting.id}'),
-                  onDelete: () => _deleteMeeting(context, ref, meeting),
+                  onDelete: role.canEdit
+                      ? () => _deleteMeeting(context, ref, meeting)
+                      : null,
                 );
               },
             ),
@@ -171,12 +173,12 @@ class _MeetingListItem extends StatelessWidget {
   const _MeetingListItem({
     required this.meeting,
     required this.onTap,
-    required this.onDelete,
+    this.onDelete,
   });
 
   final Meeting meeting;
   final VoidCallback onTap;
-  final VoidCallback onDelete;
+  final VoidCallback? onDelete;
 
   @override
   Widget build(BuildContext context) {
@@ -220,16 +222,19 @@ class _MeetingListItem extends StatelessWidget {
           style: const TextStyle(fontWeight: FontWeight.w500),
         ),
         subtitle: _buildSubtitle(),
-        trailing: IconButton(
-          icon: const Icon(Icons.delete_outline, color: AppColors.danger),
-          onPressed: onDelete,
-        ),
+        trailing: onDelete != null
+            ? IconButton(
+                icon: const Icon(Icons.delete_outline, color: AppColors.danger),
+                onPressed: onDelete,
+              )
+            : null,
       ),
     );
   }
 
   Widget? _buildSubtitle() {
-    final hasNotes = meeting.notes != null && meeting.notes!.isNotEmpty;
+    final preview = meeting.plainTextPreview;
+    final hasNotes = preview != null && preview.isNotEmpty;
     final hasAttendees = meeting.attendeeIds != null && meeting.attendeeIds!.isNotEmpty;
 
     if (!hasNotes && !hasAttendees) return null;
@@ -245,7 +250,7 @@ class _MeetingListItem extends StatelessWidget {
           ),
         if (hasNotes)
           Text(
-            meeting.notes!,
+            preview,
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
             // FN-011: Use const for better performance

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -545,7 +545,7 @@ packages:
     source: hosted
     version: "11.5.0"
   flutter_quill_delta_from_html:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: flutter_quill_delta_from_html
       sha256: "0eb801ea8dd498cadc057507af5da794d4c9599ce58b2569cb3d4bb53ba8bed2"
@@ -671,6 +671,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.15.6"
+  html_unescape:
+    dependency: transitive
+    description:
+      name: html_unescape
+      sha256: "15362d7a18f19d7b742ef8dcb811f5fd2a2df98db9f80ea393c075189e0b61e3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   http:
     dependency: "direct main"
     description:
@@ -1593,6 +1601,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "15.0.0"
+  vsc_quill_delta_to_html:
+    dependency: "direct main"
+    description:
+      name: vsc_quill_delta_to_html
+      sha256: "9aca60d53ed1b700e922dabff8cd8b3490daecbf99c258f19eb45820b794fa45"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.5"
   watcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: attendix
 description: "Attendance Management App - Flutter Version"
 publish_to: 'none'
-version: 0.1.18+19
+version: 0.1.19+20
 
 environment:
   sdk: ^3.7.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -71,6 +71,8 @@ dependencies:
 
   # Web (for service worker update detection)
   web: ^1.1.0
+  vsc_quill_delta_to_html: ^1.0.5
+  flutter_quill_delta_from_html: ^1.5.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary

- Fix critical bug: rename `attendee_ids` → `attendees` to match DB schema (was breaking all save/update operations)
- Fix notes clearing: send empty string instead of null when document is empty
- Fix list preview: extract plain text from Quill Delta JSON instead of showing raw JSON
- Handle legacy HTML notes from Ionic app (strip tags, decode entities)
- Add role check: only show delete button for users with canEdit permission

## Test plan

- [x] `dart analyze lib/` — 0 errors/warnings from changes
- [x] `flutter test` — 374/374 passed
- [ ] Manual: Settings → Besprechungen → create/edit meeting → verify attendees + notes save
- [ ] Manual: Verify legacy HTML notes display as plain text in list and detail view